### PR TITLE
Extract envoy's ID from gRPC call header

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/GrpcContextDetails.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/GrpcContextDetails.java
@@ -46,6 +46,9 @@ import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
  *   <li>Remote caller's address.
  *   An implementation of a service method can obtain this value from {@link #getCallerRemoteAddress()}.
  *   </li>
+ *   <li>Envoy ID. Each time an Envoy establishes a new connection to an Ambassador it
+ *   generates a unique, session-like ID and conveys that ID to all gRPC calls via the call headers.
+ *   </li>
  * </ul>
  */
 @GRpcGlobalInterceptor

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/LogEventRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/LogEventRouter.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.rackspace.salus.services.TelemetryEdge;
+import com.rackspace.salus.services.TelemetryEdge.LogEvent;
 import com.rackspace.salus.telemetry.ambassador.types.KafkaMessageType;
 import java.io.IOException;
 import java.util.Map;
@@ -47,8 +47,8 @@ public class LogEventRouter {
         this.kafkaEgress = kafkaEgress;
     }
 
-    public void route(String tenantId, TelemetryEdge.LogEvent request) {
-        final Map<String, String> labels = envoyRegistry.getEnvoyLabels(request.getInstanceId());
+    public void route(String tenantId, String envoyId, LogEvent request) {
+        final Map<String, String> labels = envoyRegistry.getEnvoyLabels(envoyId);
 
         try {
             final JsonNode event = objectMapper.readTree(request.getJsonContent());

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
@@ -22,6 +22,7 @@ import com.rackspace.salus.model.AccountType;
 import com.rackspace.salus.model.ExternalMetric;
 import com.rackspace.salus.model.MonitoringSystem;
 import com.rackspace.salus.services.TelemetryEdge;
+import com.rackspace.salus.services.TelemetryEdge.PostedMetric;
 import com.rackspace.salus.telemetry.ambassador.types.KafkaMessageType;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -54,11 +55,10 @@ public class MetricRouter {
         universalTimestampFormatter = DateTimeFormatter.ISO_INSTANT;
     }
 
-    public void route(String tenantId, TelemetryEdge.PostedMetric postedMetric) {
+    public void route(String tenantId, String envoyId,
+        PostedMetric postedMetric) {
 
-        final String envoyInstanceId = postedMetric.getInstanceId();
-
-        final Map<String, String> envoyLabels = envoyRegistry.getEnvoyLabels(envoyInstanceId);
+        final Map<String, String> envoyLabels = envoyRegistry.getEnvoyLabels(envoyId);
         if (envoyLabels == null) {
             throw new IllegalArgumentException("Unable to find Envoy in the registry");
         }
@@ -76,7 +76,7 @@ public class MetricRouter {
             .setTimestamp(universalTimestampFormatter.format(timestamp))
             .setDeviceMetadata(envoyLabels)
             .setMonitoringSystem(MonitoringSystem.RMII)
-            .setSystemMetadata(Collections.singletonMap("envoyId", envoyInstanceId))
+            .setSystemMetadata(Collections.singletonMap("envoyId", envoyId))
             .setCollectionMetadata(nameTagValue.getTagsMap())
             .setCollectionName(nameTagValue.getName())
             .setFvalues(nameTagValue.getFvaluesMap())

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/MockAmbassadorService.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/MockAmbassadorService.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Profile;
 public class MockAmbassadorService extends TelemetryAmbassadorGrpc.TelemetryAmbassadorImplBase {
     @Data
     public static class AttachCall {
+        final String envoyId;
         final String tenantId;
         final TelemetryEdge.EnvoySummary request;
     }
@@ -54,7 +55,11 @@ public class MockAmbassadorService extends TelemetryAmbassadorGrpc.TelemetryAmba
 
     @Override
     public void attachEnvoy(TelemetryEdge.EnvoySummary request, StreamObserver<TelemetryEdge.EnvoyInstruction> responseObserver) {
-        attachCalls.add(new AttachCall(GrpcContextDetails.getCallerTenantId(), request));
+        attachCalls.add(new AttachCall(
+            GrpcContextDetails.getCallerEnvoyId(),
+            GrpcContextDetails.getCallerTenantId(),
+            request
+        ));
 
         for (TelemetryEdge.EnvoyInstruction instruction : instructionsToProvide) {
             responseObserver.onNext(instruction);

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouterTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouterTest.java
@@ -65,7 +65,6 @@ public class MetricRouterTest {
             .thenReturn(envoyLabels);
 
         final TelemetryEdge.PostedMetric postedMetric = TelemetryEdge.PostedMetric.newBuilder()
-            .setInstanceId("envoy-1")
             .setMetric(TelemetryEdge.Metric.newBuilder()
                 .setNameTagValue(TelemetryEdge.NameTagValueMetric.newBuilder()
                     .setTimestamp(1539030613123L)
@@ -77,7 +76,7 @@ public class MetricRouterTest {
             )
             .build();
 
-        metricRouter.route("t1", postedMetric);
+        metricRouter.route("t1", "envoy-1", postedMetric);
 
         verify(envoyRegistry).getEnvoyLabels("envoy-1");
         verify(kafkaEgress).send("t1", KafkaMessageType.METRIC,


### PR DESCRIPTION
# Resolves

n/a

# What

Extract the Envoy's ID from the gRPC call header, which was placed there in https://github.com/racker/salus-telemetry-envoy/pull/22

# How

Rather than obtain the Envoy's ID from the message payload, the ID is extracted from the gRPC call headers.

## How to test

`mvn test` since there is a test that exercises the gRPC context processing.

# Why

n/a

# TODO

none