### PR TITLE
Handle envoy attach errors

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AmbassadorProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AmbassadorProperties.java
@@ -37,7 +37,7 @@ public class AmbassadorProperties {
      * FOR DEVELOPMENT ONLY, disable TLS including mutual TLS authentication
      */
     boolean disableTls = false;
-    // The following assume the working directory is $PROJECT_DIR$/dev-support
+    // The following assume the working directory is $PROJECT_DIR$/dev
     String certChainPath = "certs/out/ambassador.pem";
     String trustCertPath = "certs/out/ca.pem";
     String keyPath = "certs/out/ambassador-pkcs8-key.pem";

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
@@ -71,7 +71,11 @@ public class EnvoyAmbassadorService extends TelemetryAmbassadorGrpc.TelemetryAmb
 
         registerCancelHandler(envoyId, remoteAddr, responseObserver);
         envoyAttach.increment();
-        envoyRegistry.attach(GrpcContextDetails.getCallerTenantId(), envoyId, request, remoteAddr, responseObserver);
+        try {
+            envoyRegistry.attach(GrpcContextDetails.getCallerTenantId(), envoyId, request, remoteAddr, responseObserver);
+        } catch (StatusException e) {
+            responseObserver.onError(e);
+        }
     }
 
     private void registerCancelHandler(String instanceId, SocketAddress remoteAddr, StreamObserver<TelemetryEdge.EnvoyInstruction> responseObserver) {

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -75,6 +75,16 @@ public class EnvoyRegistry {
         this.jsonPrinter = jsonPrinter;
     }
 
+    /**
+     * Executed whenever we receive a new connection from an envoy.
+     *
+     * @param tenantId
+     * @param envoyId
+     * @param envoySummary
+     * @param remoteAddr
+     * @param instructionStreamObserver
+     * @throws StatusException
+     */
     public void attach(String tenantId, String envoyId, EnvoySummary envoySummary,
                        SocketAddress remoteAddr, StreamObserver<EnvoyInstruction> instructionStreamObserver)
                 throws StatusException {

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -91,16 +91,16 @@ public class EnvoyRegistry {
             throw new StatusException(Status.INVALID_ARGUMENT.withDescription(e.getMessage()));
         }
         final List<String> supportedAgentTypes = convertToStrings(envoySummary.getSupportedAgentsList());
-        final String envoyIdentifier = envoySummary.getIdentifier();
+        final String identifier = envoySummary.getIdentifier();
 
-        if (!envoyLabels.containsKey(envoyIdentifier)) {
+        if (!envoyLabels.containsKey(identifier)) {
             throw new StatusException(Status.INVALID_ARGUMENT.withDescription(
                     String.format("%s is not a valid value for the identifier",
-                    envoyIdentifier)));
+                    identifier)));
         }
 
         log.info("Attaching envoy tenantId={}, envoyId={} from remoteAddr={} with identifier={}, labels={}, supports agents={}",
-            tenantId, envoyId, remoteAddr, envoyIdentifier, envoyLabels, supportedAgentTypes);
+            tenantId, envoyId, remoteAddr, identifier, envoyLabels, supportedAgentTypes);
 
         envoyLeaseTracking.grant(envoyId)
             .thenCompose(leaseId -> {

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -83,8 +83,8 @@ public class EnvoyRegistry {
             log.warn("Envoy attachment from remoteAddr={} is missing tenantId", remoteAddr);
             throw new StatusException(Status.INVALID_ARGUMENT.withDescription("tenantId is missing from request"));
         }
-        final Map<String, String> envoyLabels;
 
+        final Map<String, String> envoyLabels;
         try {
             envoyLabels = labelRulesProcessor.process(envoySummary.getLabelsMap());
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
# What

Corrects the error handling when envoy's attach.

# How

We do not want to throw unhandled exceptions within the Ambassador.  Instead we throw these within the `attach` method but catch them and pass the errors back to the envoy using the StreamObserver's `onError` method.

I left `envoyAttach.increment();` untouched since it seems to be used for tracking the number of incoming connections rather than tracking a total number of active ones.

Also don't think `registerCancelHandler` has to be included in the try/catch.

## How to test

I manually tested by tweaking `label-rules.json` so that some discovered labels were considered invalid.

# Why
If I remove `darwin` from the allowed OS list, the ambassador would previously quit each time.  Now, the ambassador continues to run and I get this error in the envoy.

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/4358210/49185515-62af6e00-f31f-11e8-9609-fa57662b99ba.png">

```
time="2018-11-28T15:04:18-07:00" level=warning msg=terminating error="failed to receive instruction: rpc error: code = InvalidArgument desc = darwin is not a valid value of the label os"
```

# TODO

Add tests?
See if there are more like this?