### PR TITLE
Improve handling of etcd exceptions during shutdown

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/AgentInstallsWatcher.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/AgentInstallsWatcher.java
@@ -20,6 +20,8 @@ package com.rackspace.salus.telemetry.ambassador.services;
 
 import com.coreos.jetcd.Client;
 import com.coreos.jetcd.Watch;
+import com.coreos.jetcd.common.exception.ClosedClientException;
+import com.coreos.jetcd.common.exception.ClosedWatcherException;
 import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.data.KeyValue;
 import com.coreos.jetcd.options.WatchOption;
@@ -88,9 +90,10 @@ public class AgentInstallsWatcher {
             try {
                 final WatchResponse response = watcher.listen();
                 response.getEvents().forEach(this::processEvent);
+            } catch (ClosedClientException | ClosedWatcherException e) {
+                log.debug("Stopping watcher");
             } catch (Exception e) {
-                log.debug("Stopping watcher", e);
-                return;
+                log.warn("Unexpected exception while watching", e);
             }
         }
     }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/AppliedConfigsWatcher.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/AppliedConfigsWatcher.java
@@ -23,6 +23,8 @@ import static com.rackspace.salus.telemetry.etcd.EtcdUtils.parseValue;
 
 import com.coreos.jetcd.Client;
 import com.coreos.jetcd.Watch;
+import com.coreos.jetcd.common.exception.ClosedClientException;
+import com.coreos.jetcd.common.exception.ClosedWatcherException;
 import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.data.KeyValue;
 import com.coreos.jetcd.options.WatchOption;
@@ -95,8 +97,10 @@ public class AppliedConfigsWatcher {
                 final WatchResponse response = watcher.listen();
                 response.getEvents().forEach(this::processEvent);
 
-            } catch (InterruptedException e) {
-                log.warn("Watcher failed while listening", e);
+            } catch (ClosedClientException | ClosedWatcherException e) {
+                log.debug("Stopping watcher");
+            } catch (Exception e) {
+                log.warn("Unexpected exception while watching", e);
             }
         }
     }


### PR DESCRIPTION
# What

During normal shutdown there were some stack traces dumped at warning level while the etcd watcher services were getting closed. These logs looked worrisome, but the scenario was normal.

# How

Catch the etcd closure exceptions specifically and log at debug level.

## How to test

Manually stop the application and confirm excessive warning logs during etcd closure are not produced.

# TODO

none