### PR TITLE
Verifies resourceId during attach

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -117,6 +117,9 @@ public class EnvoyRegistry {
         }
         final List<String> supportedAgentTypes = convertToStrings(envoySummary.getSupportedAgentsList());
         final String resourceId = envoySummary.getResourceId();
+        if (!StringUtils.hasText(resourceId)) {
+            throw new StatusException(Status.INVALID_ARGUMENT.withDescription("resourceId is required"));
+        }
 
         EnvoyEntry existingEntry = envoys.get(envoyId);
         if (existingEntry != null) {

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -98,4 +98,27 @@ public class EnvoyRegistryTest {
                 .setEnvoyAddress("localhost")
         );
   }
+
+  @Test(expected = StatusException.class)
+  public void failsAttachWhenAbsentResourceId() throws StatusException {
+    final EnvoySummary envoySummary = EnvoySummary.newBuilder()
+        .putLabels("os", "linux")
+        .build();
+
+    envoyRegistry.attach("t-1", "e-1", envoySummary,
+        InetSocketAddress.createUnresolved("localhost", 60000), streamObserver
+    ).join();
+  }
+
+  @Test(expected = StatusException.class)
+  public void failsAttachWhenEmptyResourceId() throws StatusException {
+    final EnvoySummary envoySummary = EnvoySummary.newBuilder()
+        .setResourceId("    ")
+        .putLabels("os", "linux")
+        .build();
+
+    envoyRegistry.attach("t-1", "e-1", envoySummary,
+        InetSocketAddress.createUnresolved("localhost", 60000), streamObserver
+    ).join();
+  }
 }


### PR DESCRIPTION
# Resolves

SALUS-148

# What

Follow up from #15 , validates the resourceId given during attach has non-whitespace text.

## How to test

Added unit tests