### PR TITLE
Use common kafka topic configuration via @EnableSalusKafkaMessaging

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/TelemetryAmbassadorApplication.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/TelemetryAmbassadorApplication.java
@@ -18,6 +18,7 @@
 
 package com.rackspace.salus.telemetry.ambassador;
 
+import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import com.rackspace.salus.telemetry.etcd.EnableEtcd;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -26,6 +27,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableScheduling
 @EnableEtcd
+@EnableSalusKafkaMessaging
 public class TelemetryAmbassadorApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AmbassadorProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AmbassadorProperties.java
@@ -18,10 +18,8 @@
 
 package com.rackspace.salus.telemetry.ambassador.config;
 
-import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -47,6 +45,4 @@ public class AmbassadorProperties {
     List<String> altExternalNames = Collections.singletonList("127.0.0.1");
 
     long envoyLeaseSec = 30;
-
-    Map<KafkaMessageType, String> kafkaTopics;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder.buildM
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.services.TelemetryEdge;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstruction;
 import com.rackspace.salus.services.TelemetryEdge.EnvoySummary;
@@ -30,7 +31,6 @@ import com.rackspace.salus.telemetry.etcd.services.EnvoyLabelManagement;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyLeaseTracking;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.messaging.AttachEvent;
-import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
 public class EnvoyRegistry {
 
     private final AmbassadorProperties appProperties;
+    private final KafkaTopicProperties kafkaTopics;
     private final EnvoyLabelManagement envoyLabelManagement;
     private final EnvoyLeaseTracking envoyLeaseTracking;
     private final EnvoyResourceManagement envoyResourceManagement;
@@ -74,6 +75,7 @@ public class EnvoyRegistry {
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     @Autowired
     public EnvoyRegistry(AmbassadorProperties appProperties,
+                         KafkaTopicProperties kafkaTopics,
                          EnvoyLabelManagement envoyLabelManagement,
                          EnvoyLeaseTracking envoyLeaseTracking,
                          EnvoyResourceManagement envoyResourceManagement,
@@ -81,6 +83,7 @@ public class EnvoyRegistry {
                          JsonFormat.Printer jsonPrinter,
                          KafkaTemplate<String,Object> kafkaTemplate) {
         this.appProperties = appProperties;
+        this.kafkaTopics = kafkaTopics;
         this.envoyLabelManagement = envoyLabelManagement;
         this.envoyLeaseTracking = envoyLeaseTracking;
         this.envoyResourceManagement = envoyResourceManagement;
@@ -199,7 +202,7 @@ public class EnvoyRegistry {
             .setLabels(envoyLabels);
 
         kafkaTemplate.send(
-            appProperties.getKafkaTopics().get(KafkaMessageType.ATTACH),
+            kafkaTopics.getAttaches(),
             buildMessageKey(attachEvent),
             attachEvent
         );

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/KafkaEgress.java
@@ -18,7 +18,7 @@
 
 package com.rackspace.salus.telemetry.ambassador.services;
 
-import com.rackspace.salus.telemetry.ambassador.config.AmbassadorProperties;
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -28,18 +28,27 @@ import org.springframework.stereotype.Service;
 public class KafkaEgress {
 
     private final KafkaTemplate kafkaTemplate;
-    private final AmbassadorProperties ambassadorProperties;
+    private final KafkaTopicProperties kafkaTopics;
 
     @Autowired
-    public KafkaEgress(KafkaTemplate kafkaTemplate, AmbassadorProperties ambassadorProperties) {
+    public KafkaEgress(KafkaTemplate kafkaTemplate,
+                       KafkaTopicProperties kafkaTopics) {
         this.kafkaTemplate = kafkaTemplate;
-        this.ambassadorProperties = ambassadorProperties;
+        this.kafkaTopics = kafkaTopics;
     }
 
     public void send(String tenantId, KafkaMessageType messageType, String payload) {
-        final String topic = ambassadorProperties.getKafkaTopics().get(messageType);
-        if (topic == null) {
-            throw new IllegalArgumentException(String.format("No topic configured for %s", messageType));
+        final String topic;
+        switch (messageType) {
+            case METRIC:
+                topic = kafkaTopics.getMetrics();
+                break;
+            case LOG:
+                topic = kafkaTopics.getLogs();
+                break;
+            default:
+                throw new IllegalArgumentException(
+                    String.format("Unsupported messageType=%s for kafka routing", messageType));
         }
 
         kafkaTemplate.send(topic, tenantId, payload);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,5 @@
 ambassador:
   envoyRefreshInterval: PT10S
-  kafka-topics:
-    LOG:
-      telemetry.logs.json
-    METRIC:
-      telemetry.metrics.json
-    ATTACH:
-      telemetry.event.resource.json
 etcd:
   url: http://localhost:2479
 spring:

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -88,7 +88,7 @@ public class EnvoyRegistryTest {
 
     verify(kafkaTemplate)
         .send(
-            "telemetry.event.resource.json",
+            "telemetry.attaches.json",
             "t-1:hostname:test-host",
             new AttachEvent()
                 .setResourceId("hostname:test-host")


### PR DESCRIPTION
# What

Shows how `@EnableSalusKafkaMessaging` can be used in one of our applications.

# How

Uses the common `KafkaTopicsProperties` and shifts from the general purpose topic-map to well defined topic properties in the configuration.

## How to test

Existing unit tests and manual testing.