### PR TITLE
Use a taskExecutor that does thread pooling instead of simple-async

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AsyncConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AsyncConfig.java
@@ -20,14 +20,16 @@ package com.rackspace.salus.telemetry.ambassador.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 public class AsyncConfig {
 
     @Bean
     public TaskExecutor taskExecutor() {
-        return new SimpleAsyncTaskExecutor("async-");
+        final ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setThreadNamePrefix("async-");
+        return taskExecutor;
     }
 }


### PR DESCRIPTION
# What

Declare a task executor that does thread pooling since would have become a source of thread-burn when we scaled Envoys connecting to a given Ambassador.

## How to test

Unit tests for app context validation and manual otherwise.