### PR TITLE
Improve handling of attaches when Kafka connectivity is failing

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.services;
@@ -80,7 +78,10 @@ public class EnvoyAmbassadorService extends TelemetryAmbassadorGrpc.TelemetryAmb
         } catch (Exception e) {
             log.error("Unhandled exception occurred in envoy attach", e);
             exceptions.increment();
-            responseObserver.onError(new StatusException(Status.UNKNOWN.withDescription("Unknown error occurred")));
+            responseObserver.onError(
+                new StatusException(Status.UNKNOWN
+                    .withDescription("Unknown error occurred: "+e.getMessage()))
+            );
         }
     }
 


### PR DESCRIPTION
# Resolves

This would have been helpful during SALUS-94

# What

- Improves logging of exceptions that occur when Kafka is down, specifically during Envoy attachment where the resource event is sent
- Broadens some of the catch expression to pick up exceptions thrown during Kafka connectivity issues
- Propagates the exception message back to the Envoy error response to improve troubleshooting of the Envoy in these cases
- Arranges parts of the attachment completable-future chain to only perform steps like retrieving configs until after the Kafka resource event was successfully produced

## How to test

Stopped the Kafka container locally and started an Envoy.