### PR TITLE
Split cloudbuild.yaml for test vs container deploy

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -53,10 +53,29 @@ steps:
     - name: user.home
       path: /root
 
+  - id: COMPILE_AND_PUSH_CONTAINER
+    name: 'gcr.io/cloud-builders/mvn'
+    env:
+    - 'SHORT_SHA=$SHORT_SHA'
+    args:
+    - compile
+    # Runs the Jib build by using the latest version of the plugin.
+    # To use a specific version, configure the plugin in the pom.xml.
+    - jib:build
+    # Skip Tests since it happened in the previous test
+    - "-Dmaven.test.skip=true"
+    # Ensure we name the image correctly since its not in pom.xml
+    - "-Ddocker.image.prefix=gcr.io/$PROJECT_ID"
+    - "-s"
+    - .mvn/settings.xml
+    volumes:
+    - name: user.home
+      path: /root
+
   # Saves the files to the GCS cache.
   - id: PUSH_UP_CACHE
     waitFor:
-    - DEPLOY
+    - COMPILE_AND_PUSH_CONTAINER
     name: gcr.io/cloud-builders/gsutil
     dir: /root
     entrypoint: bash

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,25 +4,6 @@ substitutions:
 
 steps:
 
-    # This is ugly because of
-    # https://github.com/GoogleContainerTools/jib/issues/1500#issuecomment-466207421
-  - id: FIX_DOCKER
-    name: gcr.io/cloud-builders/mvn
-    waitFor: ['-']
-    dir: /root
-    entrypoint: bash
-    args:
-    - -c
-    - # Links the Docker config to /root/.docker/config.json so that Jib picks it up.
-      # Note that this is only a temporary workaround.
-      # See https://github.com/GoogleContainerTools/jib/pull/1479.
-      |
-      mkdir .docker &&
-      ln -vs $$HOME/.docker/config.json .docker/config.json
-    volumes:
-    - name: user.home
-      path: /root
-
   # Pull down settings file for Artifactory settings
   - id: GET_SETTINGS
     name: 'gcr.io/cloud-builders/gsutil'


### PR DESCRIPTION
# Resolves
Jira [SALUS-233](https://jira.rax.io/browse/SALUS-233) 

# What
Splits the cloudbuild.yaml into one for tests/snapshot deploy and one for docker container deployment.