### PR TITLE
fixed resource id in metric router test

### DIFF
--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouterTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouterTest.java
@@ -64,6 +64,9 @@ public class MetricRouterTest {
         when(envoyRegistry.getEnvoyLabels(any()))
             .thenReturn(envoyLabels);
 
+        when(envoyRegistry.getResourceId(any()))
+            .thenReturn("resourceId");
+
         final TelemetryEdge.PostedMetric postedMetric = TelemetryEdge.PostedMetric.newBuilder()
             .setMetric(TelemetryEdge.Metric.newBuilder()
                 .setNameTagValue(TelemetryEdge.NameTagValueMetric.newBuilder()
@@ -79,8 +82,9 @@ public class MetricRouterTest {
         metricRouter.route("t1", "envoy-1", postedMetric);
 
         verify(envoyRegistry).getEnvoyLabels("envoy-1");
+        verify(envoyRegistry).getResourceId("envoy-1");
         verify(kafkaEgress).send("t1", KafkaMessageType.METRIC,
-            "{\"timestamp\":\"2018-10-08T20:30:13.123Z\",\"accountType\":\"RCN\",\"account\":\"t1\",\"device\":\"\",\"deviceLabel\":\"\",\"deviceMetadata\":{\"hostname\":\"host1\",\"os\":\"linux\"},\"monitoringSystem\":\"SALUS\",\"systemMetadata\":{\"envoyId\":\"envoy-1\"},\"collectionName\":\"cpu\",\"collectionLabel\":\"\",\"collectionTarget\":\"\",\"collectionMetadata\":{\"cpu\":\"cpu1\"},\"ivalues\":{},\"fvalues\":{\"usage\":1.45},\"svalues\":{\"status\":\"enabled\"},\"units\":{}}");
+            "{\"timestamp\":\"2018-10-08T20:30:13.123Z\",\"accountType\":\"RCN\",\"account\":\"t1\",\"device\":\"resourceId\",\"deviceLabel\":\"\",\"deviceMetadata\":{\"hostname\":\"host1\",\"os\":\"linux\"},\"monitoringSystem\":\"SALUS\",\"systemMetadata\":{\"envoyId\":\"envoy-1\"},\"collectionName\":\"cpu\",\"collectionLabel\":\"\",\"collectionTarget\":\"\",\"collectionMetadata\":{\"cpu\":\"cpu1\"},\"ivalues\":{},\"fvalues\":{\"usage\":1.45},\"svalues\":{\"status\":\"enabled\"},\"units\":{}}");
 
         verifyNoMoreInteractions(kafkaEgress, envoyRegistry);
     }


### PR DESCRIPTION
The metric router test in master is failing.  It looks like it was never updated for the new resource Id.    This PR fixes that.