### PR TITLE
ExternalMetric has moved to umb-protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
             <artifactId>salus-telemetry-protocol</artifactId>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>com.rackspace.monplat</groupId>
+            <artifactId>umb-protocol</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+        </dependency>
 
         <dependency>
             <groupId>org.lognet</groupId>

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
@@ -18,9 +18,9 @@
 
 package com.rackspace.salus.telemetry.ambassador.services;
 
-import com.rackspace.salus.model.AccountType;
-import com.rackspace.salus.model.ExternalMetric;
-import com.rackspace.salus.model.MonitoringSystem;
+import com.rackspace.monplat.protocol.AccountType;
+import com.rackspace.monplat.protocol.ExternalMetric;
+import com.rackspace.monplat.protocol.MonitoringSystem;
 import com.rackspace.salus.services.TelemetryEdge;
 import com.rackspace.salus.services.TelemetryEdge.PostedMetric;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;


### PR DESCRIPTION
# What

Switches over to umb-protocol for the declaration of `ExternalMetric`.

# How

Added the dependency and adjusted package import.

## How to test

Existing unit tests