### PR TITLE
Use BoundMonitorDTO from monitor management client jar

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/BoundMonitorUtils.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/BoundMonitorUtils.java
@@ -16,14 +16,14 @@
 
 package com.rackspace.salus.telemetry.ambassador.services;
 
-import com.rackspace.salus.monitor_management.entities.BoundMonitor;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 
 public class BoundMonitorUtils {
 
   public static final String LABEL_TARGET_TENANT = "target_tenant";
   public static final String LABEL_RESOURCE = "resource_id";
 
-  public static String buildConfiguredMonitorId(BoundMonitor boundMonitor) {
+  public static String buildConfiguredMonitorId(BoundMonitorDTO boundMonitor) {
     return String.join("_", boundMonitor.getMonitorId().toString(), boundMonitor.getResourceId());
   }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
@@ -16,7 +16,7 @@
 
 package com.rackspace.salus.telemetry.ambassador.services;
 
-import com.rackspace.salus.monitor_management.entities.BoundMonitor;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.services.TelemetryEdge;
 import com.rackspace.salus.services.TelemetryEdge.ConfigurationOp;
 import com.rackspace.salus.services.TelemetryEdge.ConfigurationOp.Type;
@@ -49,7 +49,7 @@ public class ConfigInstructionsBuilder {
   }
 
   public ConfigInstructionsBuilder add(
-      BoundMonitor boundMonitor,
+      BoundMonitorDTO boundMonitor,
       OperationType operationType) {
     final Builder builder = buildersByAgentType.computeIfAbsent(
         boundMonitor.getAgentType(),
@@ -73,7 +73,7 @@ public class ConfigInstructionsBuilder {
     return this;
   }
 
-  private boolean isRemoteMonitor(BoundMonitor boundMonitor) {
+  private boolean isRemoteMonitor(BoundMonitorDTO boundMonitor) {
     return StringUtils.hasText(boundMonitor.getZone());
   }
 

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MonitorEventListener.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MonitorEventListener.java
@@ -17,8 +17,8 @@
 package com.rackspace.salus.telemetry.ambassador.services;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
-import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import com.rackspace.salus.monitor_management.web.client.MonitorApi;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstruction;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
 import com.rackspace.salus.telemetry.messaging.OperationType;
@@ -70,18 +70,18 @@ public class MonitorEventListener implements ConsumerSeekAware {
 
     log.debug("Handling monitorBoundEvent={}", event);
 
-    final List<BoundMonitor> boundMonitors = monitorApi.getBoundMonitors(envoyId);
+    final List<BoundMonitorDTO> boundMonitors = monitorApi.getBoundMonitors(envoyId);
 
     // reconcile all bound monitors for this envoy and determine what operation types to send
 
-    final Map<OperationType, List<BoundMonitor>> changes = envoyRegistry.applyBoundMonitors(envoyId, boundMonitors);
+    final Map<OperationType, List<BoundMonitorDTO>> changes = envoyRegistry.applyBoundMonitors(envoyId, boundMonitors);
     log.debug("Applied boundMonitors and computed changes={}", changes);
 
     // transform bound monitor changes into instructions
 
     final ConfigInstructionsBuilder instructionsBuilder = new ConfigInstructionsBuilder();
-    for (Entry<OperationType, List<BoundMonitor>> entry : changes.entrySet()) {
-      for (BoundMonitor boundMonitor : entry.getValue()) {
+    for (Entry<OperationType, List<BoundMonitorDTO>> entry : changes.entrySet()) {
+      for (BoundMonitorDTO boundMonitor : entry.getValue()) {
         instructionsBuilder.add(
             boundMonitor,
             entry.getKey()

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
-import com.rackspace.salus.monitor_management.entities.BoundMonitor;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.services.TelemetryEdge;
 import com.rackspace.salus.services.TelemetryEdge.ConfigurationOp.Type;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstruction;
@@ -49,7 +49,7 @@ public class ConfigInstructionsBuilderTest {
     final UUID m5 = UUID.fromString("00000000-0000-0005-0000-000000000000");
 
     builder.add(
-        new BoundMonitor()
+        new BoundMonitorDTO()
             .setAgentType(TELEGRAF)
             .setRenderedContent("content1")
             .setMonitorId(m1)
@@ -57,7 +57,7 @@ public class ConfigInstructionsBuilderTest {
         OperationType.CREATE
     );
     builder.add(
-        new BoundMonitor()
+        new BoundMonitorDTO()
             .setAgentType(TELEGRAF)
             .setRenderedContent("content2")
             .setMonitorId(m2)
@@ -65,7 +65,7 @@ public class ConfigInstructionsBuilderTest {
         OperationType.UPDATE
     );
     builder.add(
-        new BoundMonitor()
+        new BoundMonitorDTO()
             .setAgentType(TELEGRAF)
             .setRenderedContent("")
             .setMonitorId(m3)
@@ -73,7 +73,7 @@ public class ConfigInstructionsBuilderTest {
         OperationType.DELETE
     );
     builder.add(
-        new BoundMonitor()
+        new BoundMonitorDTO()
             .setAgentType(FILEBEAT)
             .setRenderedContent("content4")
             .setMonitorId(m4)
@@ -81,7 +81,7 @@ public class ConfigInstructionsBuilderTest {
         OperationType.CREATE
     );
     builder.add(
-        new BoundMonitor()
+        new BoundMonitorDTO()
             .setAgentType(TELEGRAF)
             .setRenderedContent("content5")
             .setMonitorId(m5)

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -13,7 +13,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.rackspace.salus.monitor_management.entities.BoundMonitor;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstruction;
 import com.rackspace.salus.services.TelemetryEdge.EnvoySummary;
 import com.rackspace.salus.telemetry.ambassador.config.AmbassadorProperties;
@@ -230,23 +230,23 @@ public class EnvoyRegistryTest {
     final UUID id4 = UUID.fromString("16caf730-48e8-47ba-0004-aa9babba8953");
 
     {
-      final List<BoundMonitor> boundMonitors = Arrays.asList(
-          new BoundMonitor()
+      final List<BoundMonitorDTO> boundMonitors = Arrays.asList(
+          new BoundMonitorDTO()
               .setMonitorId(id1)
               .setRenderedContent("{\"instance\":1, \"state\":1}"),
-          new BoundMonitor()
+          new BoundMonitorDTO()
               .setMonitorId(id2)
               .setResourceId("r-2")
               .setAgentType(AgentType.TELEGRAF)
               .setRenderedContent("{\"instance\":2, \"state\":1}"),
-          new BoundMonitor()
+          new BoundMonitorDTO()
               .setMonitorId(id3)
               .setTargetTenant("t-1")
               .setZone("z-1")
               .setResourceId("r-3")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
           // monitor binding for another resource for the same tenant
-          new BoundMonitor()
+          new BoundMonitorDTO()
               .setMonitorId(id3)
               .setTargetTenant("t-1")
               .setZone("z-1")
@@ -254,7 +254,7 @@ public class EnvoyRegistryTest {
               .setRenderedContent("{\"instance\":3, \"state\":1}")
       );
 
-      final Map<OperationType, List<BoundMonitor>> changes = envoyRegistry
+      final Map<OperationType, List<BoundMonitorDTO>> changes = envoyRegistry
           .applyBoundMonitors("e-1", boundMonitors);
 
       assertThat(changes, notNullValue());
@@ -265,33 +265,33 @@ public class EnvoyRegistryTest {
 
     {
       // Exercise some changes
-      final List<BoundMonitor> boundMonitors = Arrays.asList(
+      final List<BoundMonitorDTO> boundMonitors = Arrays.asList(
           // #1 MODIFIED
-          new BoundMonitor()
+          new BoundMonitorDTO()
               .setMonitorId(id1)
               .setRenderedContent("{\"instance\":1, \"state\":2}"),
           // #2 REMOVED
           // #3 UNCHANGED for both resources
-          new BoundMonitor()
+          new BoundMonitorDTO()
               .setMonitorId(id3)
               .setTargetTenant("t-1")
               .setZone("z-1")
               .setResourceId("r-3")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
           // monitor binding for another resource for the same tenant
-          new BoundMonitor()
+          new BoundMonitorDTO()
               .setMonitorId(id3)
               .setTargetTenant("t-1")
               .setZone("z-1")
               .setResourceId("r-4")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
           // #4 CREATED
-          new BoundMonitor()
+          new BoundMonitorDTO()
               .setMonitorId(id4)
               .setRenderedContent("{\"instance\":4, \"state\":1}")
       );
 
-      final Map<OperationType, List<BoundMonitor>> changes = envoyRegistry
+      final Map<OperationType, List<BoundMonitorDTO>> changes = envoyRegistry
           .applyBoundMonitors("e-1", boundMonitors);
 
       assertThat(changes, notNullValue());
@@ -300,7 +300,7 @@ public class EnvoyRegistryTest {
       assertThat(changes.get(OperationType.UPDATE), hasSize(1));
       assertThat(changes.get(OperationType.UPDATE), hasItem(hasProperty("monitorId", equalTo(id1))));
       assertThat(changes.get(OperationType.DELETE), hasSize(1));
-      final List<BoundMonitor> deleted = changes.get(OperationType.DELETE);
+      final List<BoundMonitorDTO> deleted = changes.get(OperationType.DELETE);
       assertThat(deleted.get(0).getAgentType(), equalTo(AgentType.TELEGRAF));
       assertThat(deleted.get(0).getMonitorId(), equalTo(id2));
       assertThat(deleted.get(0).getResourceId(), equalTo("r-2"));

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MonitorEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MonitorEventListenerTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
-import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import com.rackspace.salus.monitor_management.web.client.MonitorApi;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.services.TelemetryEdge;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstruction;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstructionConfigure;
@@ -74,14 +74,16 @@ public class MonitorEventListenerTest {
     final UUID id1 = UUID.randomUUID();
     final UUID id2 = UUID.randomUUID();
 
-    List<BoundMonitor> boundMonitors = Arrays.asList(
-        new BoundMonitor()
+    List<BoundMonitorDTO> boundMonitors = Arrays.asList(
+        new BoundMonitorDTO()
         .setMonitorId(id1)
+        .setResourceId("r-1")
         .setAgentType(AgentType.TELEGRAF)
         .setTargetTenant("t-1")
         .setRenderedContent("content1"),
-        new BoundMonitor()
+        new BoundMonitorDTO()
         .setMonitorId(id2)
+        .setResourceId("r-2")
         .setAgentType(AgentType.FILEBEAT)
         .setTargetTenant("t-2")
         .setRenderedContent("content2")
@@ -93,7 +95,7 @@ public class MonitorEventListenerTest {
     when(envoyRegistry.contains("e-1"))
         .thenReturn(true);
 
-    Map<OperationType, List<BoundMonitor>> changes = new HashMap<>();
+    Map<OperationType, List<BoundMonitorDTO>> changes = new HashMap<>();
     changes.put(OperationType.CREATE, boundMonitors);
 
     when(envoyRegistry.applyBoundMonitors(any(), any()))
@@ -118,14 +120,14 @@ public class MonitorEventListenerTest {
     assertThat(configure0, notNullValue());
     assertThat(configure0.getAgentType(), equalTo(TelemetryEdge.AgentType.TELEGRAF));
     assertThat(configure0.getOperationsList(), hasSize(1));
-    assertThat(configure0.getOperations(0).getId(), equalTo(id1.toString()));
+    assertThat(configure0.getOperations(0).getId(), equalTo(id1.toString()+"_r-1"));
 
     final EnvoyInstructionConfigure configure1 = envoyInstructionArg.getAllValues().get(1)
         .getConfigure();
     assertThat(configure1, notNullValue());
     assertThat(configure1.getAgentType(), equalTo(TelemetryEdge.AgentType.FILEBEAT));
     assertThat(configure1.getOperationsList(), hasSize(1));
-    assertThat(configure1.getOperations(0).getId(), equalTo(id2.toString()));
+    assertThat(configure1.getOperations(0).getId(), equalTo(id2.toString()+"_r-2"));
 
     verifyNoMoreInteractions(envoyRegistry, monitorApi);
   }


### PR DESCRIPTION
# Resolves

Fixes an issue from the previous PR https://github.com/racker/salus-telemetry-ambassador/pull/31 that was caused by https://github.com/racker/salus-telemetry-monitor-management/pull/14

# What

When the code previously referenced `BoundMonitor`, which isn't actually included by the client jar of monitor management, the javac compiler itself was failing weirdly with a NullPointerException.

# How

Use the new `BoundMonitorDTO`

## How to test

Existing unit tests