### PR TITLE
Update for BoundMonitor rename of zoneId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-protocol</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>0.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.monplat</groupId>

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
@@ -74,7 +74,7 @@ public class ConfigInstructionsBuilder {
   }
 
   private boolean isRemoteMonitor(BoundMonitorDTO boundMonitor) {
-    return StringUtils.hasText(boundMonitor.getZone());
+    return StringUtils.hasText(boundMonitor.getZoneId());
   }
 
 

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
@@ -63,10 +63,8 @@ public class ConfigInstructionsBuilder {
         .setType(convertOpType(operationType))
         .setContent(boundMonitor.getRenderedContent());
 
-    if (StringUtils.hasText(boundMonitor.getTargetTenant())) {
-      opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_TARGET_TENANT, boundMonitor.getTargetTenant());
-    }
     if (isRemoteMonitor(boundMonitor)) {
+      opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_TARGET_TENANT, boundMonitor.getResourceTenant());
       opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_RESOURCE, boundMonitor.getResourceId());
     }
 

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ZoneAuthorizer.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ZoneAuthorizer.java
@@ -62,15 +62,10 @@ public class ZoneAuthorizer {
         throw new ZoneNotAuthorizedException(tenantId, zone);
       }
 
-      return new ResolvedZone()
-          .setPublicZone(true)
-          .setId(zone);
+      return ResolvedZone.createPublicZone(zone);
     }
     else {
-      return new ResolvedZone()
-          .setPublicZone(false)
-          .setId(zone)
-          .setTenantId(tenantId);
+      return ResolvedZone.createPrivateZone(tenantId, zone);
     }
   }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
@@ -87,7 +87,7 @@ public class ConfigInstructionsBuilderTest {
             .setMonitorId(m5)
             .setTargetTenant("t-1")
             .setResourceId("r-2")
-            .setZone("z-1"),
+            .setZoneId("z-1"),
         OperationType.CREATE
     );
 

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
@@ -85,7 +85,7 @@ public class ConfigInstructionsBuilderTest {
             .setAgentType(TELEGRAF)
             .setRenderedContent("content5")
             .setMonitorId(m5)
-            .setTargetTenant("t-1")
+            .setResourceTenant("t-1")
             .setResourceId("r-2")
             .setZoneId("z-1"),
         OperationType.CREATE

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -242,14 +242,14 @@ public class EnvoyRegistryTest {
           new BoundMonitorDTO()
               .setMonitorId(id3)
               .setTargetTenant("t-1")
-              .setZone("z-1")
+              .setZoneId("z-1")
               .setResourceId("r-3")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
           // monitor binding for another resource for the same tenant
           new BoundMonitorDTO()
               .setMonitorId(id3)
               .setTargetTenant("t-1")
-              .setZone("z-1")
+              .setZoneId("z-1")
               .setResourceId("r-4")
               .setRenderedContent("{\"instance\":3, \"state\":1}")
       );
@@ -275,14 +275,14 @@ public class EnvoyRegistryTest {
           new BoundMonitorDTO()
               .setMonitorId(id3)
               .setTargetTenant("t-1")
-              .setZone("z-1")
+              .setZoneId("z-1")
               .setResourceId("r-3")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
           // monitor binding for another resource for the same tenant
           new BoundMonitorDTO()
               .setMonitorId(id3)
               .setTargetTenant("t-1")
-              .setZone("z-1")
+              .setZoneId("z-1")
               .setResourceId("r-4")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
           // #4 CREATED

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -156,9 +156,7 @@ public class EnvoyRegistryTest {
     when(envoyResourceManagement.registerResource(any(), any(), anyLong(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ResourceInfo()));
 
-    final ResolvedZone resolvedZone = new ResolvedZone()
-        .setId("z-1")
-        .setTenantId("t-1");
+    final ResolvedZone resolvedZone = ResolvedZone.createPrivateZone("t-1", "z-1");
     when(zoneAuthorizer.authorize("t-1", "z-1"))
         .thenReturn(resolvedZone);
 

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -241,14 +241,14 @@ public class EnvoyRegistryTest {
               .setRenderedContent("{\"instance\":2, \"state\":1}"),
           new BoundMonitorDTO()
               .setMonitorId(id3)
-              .setTargetTenant("t-1")
+              .setResourceTenant("t-1")
               .setZoneId("z-1")
               .setResourceId("r-3")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
           // monitor binding for another resource for the same tenant
           new BoundMonitorDTO()
               .setMonitorId(id3)
-              .setTargetTenant("t-1")
+              .setResourceTenant("t-1")
               .setZoneId("z-1")
               .setResourceId("r-4")
               .setRenderedContent("{\"instance\":3, \"state\":1}")
@@ -274,14 +274,14 @@ public class EnvoyRegistryTest {
           // #3 UNCHANGED for both resources
           new BoundMonitorDTO()
               .setMonitorId(id3)
-              .setTargetTenant("t-1")
+              .setResourceTenant("t-1")
               .setZoneId("z-1")
               .setResourceId("r-3")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
           // monitor binding for another resource for the same tenant
           new BoundMonitorDTO()
               .setMonitorId(id3)
-              .setTargetTenant("t-1")
+              .setResourceTenant("t-1")
               .setZoneId("z-1")
               .setResourceId("r-4")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MonitorEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MonitorEventListenerTest.java
@@ -102,8 +102,7 @@ public class MonitorEventListenerTest {
         .thenReturn(changes);
 
     MonitorBoundEvent event = new MonitorBoundEvent()
-        .setEnvoyId("e-1")
-        .setOperationType(OperationType.CREATE);
+        .setEnvoyId("e-1");
 
     monitorEventListener.handleMessage(event);
 

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MonitorEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MonitorEventListenerTest.java
@@ -79,13 +79,13 @@ public class MonitorEventListenerTest {
         .setMonitorId(id1)
         .setResourceId("r-1")
         .setAgentType(AgentType.TELEGRAF)
-        .setTargetTenant("t-1")
+        .setResourceTenant("t-1")
         .setRenderedContent("content1"),
         new BoundMonitorDTO()
         .setMonitorId(id2)
         .setResourceId("r-2")
         .setAgentType(AgentType.FILEBEAT)
-        .setTargetTenant("t-2")
+        .setResourceTenant("t-2")
         .setRenderedContent("content2")
     );
 


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-263

# What

In https://github.com/racker/salus-telemetry-monitor-management/pull/17 I had renamed a few fields in `BoundMonitor` to better clarify the purpose of the field. Not only did `targetTenant` get renamed to `resourceTenant` I also ensured it is always populated with the tenant's ID. As such, the extra per-plugin tags are added together when it sees it is a remote bound monitor via a non-empty zone designation.

## How to test

Unit tests updated

# Depends on
- https://github.com/racker/salus-telemetry-monitor-management/pull/17