### PR TITLE
Add zone validation for envoys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,12 @@
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>uk.co.jemos.podam</groupId>
+            <artifactId>podam</artifactId>
+            <version>7.2.1.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/RestClientsConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/RestClientsConfig.java
@@ -18,6 +18,8 @@ package com.rackspace.salus.telemetry.ambassador.config;
 
 import com.rackspace.salus.monitor_management.web.client.MonitorApi;
 import com.rackspace.salus.monitor_management.web.client.MonitorApiClient;
+import com.rackspace.salus.monitor_management.web.client.ZoneApi;
+import com.rackspace.salus.monitor_management.web.client.ZoneApiClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
@@ -39,6 +41,15 @@ public class RestClientsConfig {
         restTemplateBuilder
             .rootUri(servicesProperties.getMonitorManagementUrl())
             .build()
+    );
+  }
+
+  @Bean
+  public ZoneApi zoneApi(RestTemplateBuilder restTemplateBuilder) {
+    return new ZoneApiClient(
+            restTemplateBuilder
+                    .rootUri(servicesProperties.getMonitorManagementUrl())
+                    .build()
     );
   }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -172,6 +172,9 @@ public class EnvoyRegistry {
             unauthorizedZoneCounter.increment();
             log.warn("Envoy attachment from remoteAddr={} is unauthorized: {}", remoteAddr, e.getMessage());
             throw new StatusException(Status.INVALID_ARGUMENT.withDescription(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            log.debug("Envoy attachment from remoteAddr={} specified invalid zone: {}", remoteAddr, e.getMessage());
+            throw new StatusException(Status.INVALID_ARGUMENT.withDescription(e.getMessage()));
         }
 
         final Map<String, String> envoyLabels = processEnvoyLabels(envoySummary);

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ZoneAuthorizerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ZoneAuthorizerTest.java
@@ -16,27 +16,47 @@
 
 package com.rackspace.salus.telemetry.ambassador.services;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
 
+import com.rackspace.salus.monitor_management.web.client.ZoneApi;
+import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
 import com.rackspace.salus.telemetry.ambassador.config.AmbassadorProperties;
 import com.rackspace.salus.telemetry.ambassador.types.ZoneNotAuthorizedException;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import java.util.Collections;
-import org.junit.Test;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+@RunWith(SpringRunner.class)
 public class ZoneAuthorizerTest {
+
+  @MockBean
+  ZoneApi zoneApi;
+
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
 
   @Test
   public void testNonPublic() throws ZoneNotAuthorizedException {
     AmbassadorProperties properties = new AmbassadorProperties();
     properties.setPublicZonePrefix("public/");
 
-    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties);
+    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties, zoneApi);
 
-    final ResolvedZone zone = authorizer.authorize("any tenant", "notPublic");
+    ZoneDTO zoneDTO = podamFactory.manufacturePojo(ZoneDTO.class);
+    zoneDTO.setName("notPublic");
+
+    when(zoneApi.getAvailableZones(anyString())).thenReturn(Collections.singletonList(zoneDTO));
+
+    final ResolvedZone zone = authorizer.authorize("any tenant", zoneDTO.getName());
 
     assertThat(zone, notNullValue());
     assertThat(zone.getId(), equalTo("notPublic"));
@@ -49,7 +69,7 @@ public class ZoneAuthorizerTest {
     AmbassadorProperties properties = new AmbassadorProperties();
     properties.setPublicZonePrefix("public/");
 
-    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties);
+    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties, zoneApi);
 
     // should fail
     authorizer.authorize("any tenant", "public/us-east");
@@ -61,7 +81,7 @@ public class ZoneAuthorizerTest {
     properties.setPublicZonePrefix("public/");
     properties.setPublicZoneTenants(Collections.singletonList("admin-tenant"));
 
-    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties);
+    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties, zoneApi);
 
     // should fail
     authorizer.authorize("any tenant", "public/us-east");
@@ -73,19 +93,37 @@ public class ZoneAuthorizerTest {
     properties.setPublicZonePrefix("public/");
     properties.setPublicZoneTenants(Collections.singletonList("admin-tenant"));
 
-    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties);
+    ZoneDTO zoneDTO = podamFactory.manufacturePojo(ZoneDTO.class);
+    zoneDTO.setName("public/us-east");
 
-    final ResolvedZone zone = authorizer.authorize("admin-tenant", "public/us-east");
+    when(zoneApi.getAvailableZones(anyString())).thenReturn(Collections.singletonList(zoneDTO));
+
+    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties, zoneApi);
+
+    final ResolvedZone zone = authorizer.authorize("admin-tenant", zoneDTO.getName());
 
     assertThat(zone, notNullValue());
     assertThat(zone.getId(), equalTo("public/us-east"));
     assertThat(zone.isPublicZone(), equalTo(true));
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testPublicZoneDoesntExist() throws ZoneNotAuthorizedException {
+    AmbassadorProperties properties = new AmbassadorProperties();
+    properties.setPublicZonePrefix("public/");
+    properties.setPublicZoneTenants(Collections.singletonList("admin-tenant"));
+
+    when(zoneApi.getAvailableZones(anyString())).thenReturn(Collections.emptyList());
+
+    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties, zoneApi);
+
+    authorizer.authorize("admin-tenant", "public/us-east");
+  }
+
   @Test
   public void testResolvingNullZone() throws ZoneNotAuthorizedException {
     AmbassadorProperties properties = new AmbassadorProperties();
-    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties);
+    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties, zoneApi);
 
     final ResolvedZone zone = authorizer.authorize("any-tenant", null);
 
@@ -95,7 +133,7 @@ public class ZoneAuthorizerTest {
   @Test
   public void testResolvingEmptyZone() throws ZoneNotAuthorizedException {
     AmbassadorProperties properties = new AmbassadorProperties();
-    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties);
+    final ZoneAuthorizer authorizer = new ZoneAuthorizer(properties, zoneApi);
 
     final ResolvedZone zone = authorizer.authorize("any-tenant", "");
 


### PR DESCRIPTION
# What



# How

Makes requests via the zone api to get the list of zones for a tenant and make sure the envoy provided zone matches those.  If not it fails the envoy attachment.

## How to test

Since it involves envoy attachment, this is done via manual testing.

1. Start up dev env
1. Run envoy with a zone value that doesn't exist.
1. Watch it fail
1. Create zone
1. See it connect

# Why

Zones should not get created automatically when an envoy connects.  They should be created via the api and envoys can only connect as part of that zone if the zone already exists.

It reduces the chances of zones being created incorrectly due to typos in the config file.

# TODO

Decide what to do for
```
    } catch (ResourceAccessException e) {
      // need to do something here to handle things more gracefully.
      throw new RuntimeException("Unable to validate zones.");
    }
```