### PR TITLE
Optional BuildProperties to ease development setup

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/MetricsConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/MetricsConfig.java
@@ -29,8 +29,7 @@ import org.springframework.context.annotation.Configuration;
 public class MetricsConfig {
   private final BuildProperties buildProperties;
 
-  @Autowired
-  public MetricsConfig(BuildProperties buildProperties) {
+  public MetricsConfig(@Autowired(required = false) BuildProperties buildProperties) {
     this.buildProperties = buildProperties;
   }
 
@@ -46,7 +45,7 @@ public class MetricsConfig {
       }
 
       registry.config().commonTags(
-          "app", buildProperties.getName(),
+          "app", buildProperties != null ? buildProperties.getName() : "salus-telemetry-ambassador",
           "host", ourHostname);
     };
   }


### PR DESCRIPTION
# What

Without this change, `MetricsConfig` would fail the application startup if the `target/classes/META-INF/build.properties` file hadn't been generated yet by the Spring Boot maven plugin.

# How

Allow that bean to be optional so that we don't need to run `mvn compile` in our development environment just so we can run the application.

## How to test

Existing unit tests