### PR TITLE
Use ResourceDTO instead of Resource

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ResourceLabelsService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ResourceLabelsService.java
@@ -18,9 +18,9 @@ package com.rackspace.salus.telemetry.ambassador.services;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.ambassador.types.ResourceKey;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
-import com.rackspace.salus.telemetry.model.Resource;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.net.InetAddress;
@@ -129,7 +129,7 @@ public class ResourceLabelsService implements ConsumerSeekAware {
             log.debug("Trying to query for tenantId={} resourceId={} try={}",
                 tenantId, resourceId, retryContext.getRetryCount());
 
-            final Resource resource = resourceApi.getByResourceId(tenantId, resourceId);
+            final ResourceDTO resource = resourceApi.getByResourceId(tenantId, resourceId);
 
             return resource.getLabels();
           },

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ResourceLabelsServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ResourceLabelsServiceTest.java
@@ -29,8 +29,8 @@ import static org.mockito.Mockito.when;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
-import com.rackspace.salus.telemetry.model.Resource;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.net.UnknownHostException;
@@ -101,7 +101,7 @@ public class ResourceLabelsServiceTest {
 
     when(resourceApi.getByResourceId("t-1", "r-1"))
         .thenReturn(
-            new Resource()
+            new ResourceDTO()
             .setLabels(expectedLabels)
         );
 
@@ -124,7 +124,7 @@ public class ResourceLabelsServiceTest {
     when(resourceApi.getByResourceId("t-1", "r-1"))
         .thenThrow(ResourceAccessException.class)
         .thenReturn(
-            new Resource()
+            new ResourceDTO()
                 .setLabels(expectedLabels)
         );
 
@@ -165,7 +165,7 @@ public class ResourceLabelsServiceTest {
 
     when(resourceApi.getByResourceId("t-1", "r-1"))
         .thenReturn(
-            new Resource()
+            new ResourceDTO()
                 .setLabels(expectedLabels)
         );
 
@@ -211,8 +211,8 @@ public class ResourceLabelsServiceTest {
   public void test_handResourceEvent_tracking() {
 
     when(resourceApi.getByResourceId("t-1", "r-1"))
-        .thenReturn(new Resource().setLabels(singletonMap("env", "pre")))
-        .thenReturn(new Resource().setLabels(singletonMap("env", "post")));
+        .thenReturn(new ResourceDTO().setLabels(singletonMap("env", "pre")))
+        .thenReturn(new ResourceDTO().setLabels(singletonMap("env", "post")));
 
     resourceLabelsService.trackResource("t-1", "r-1");
 


### PR DESCRIPTION
# What

1. Updates to use `ResourceDTO` instead of `Resource`

# How

1. Search and Replace mostly.

## How to test

Existing tests

# Why

1. The resource api changed in https://github.com/racker/salus-telemetry-resource-management/pull/33