### PR TITLE
Include monitor ID in the metrics emitted from Ambassador (from Envoy)

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/BoundMonitorUtils.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/BoundMonitorUtils.java
@@ -22,6 +22,7 @@ public class BoundMonitorUtils {
 
   public static final String LABEL_TARGET_TENANT = "target_tenant";
   public static final String LABEL_RESOURCE = "resource_id";
+  public static final String LABEL_MONITOR_ID = "monitor_id";
 
   public static String buildConfiguredMonitorId(BoundMonitorDTO boundMonitor) {
     // don't need to qualify resource ID by resource tenant since monitor ID is already distinct

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
@@ -63,6 +63,8 @@ public class ConfigInstructionsBuilder {
         .setType(convertOpType(operationType))
         .setContent(boundMonitor.getRenderedContent());
 
+    opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_MONITOR_ID, boundMonitor.getMonitorId().toString());
+
     if (isRemoteMonitor(boundMonitor)) {
       opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_TARGET_TENANT, boundMonitor.getResourceTenant());
       opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_RESOURCE, boundMonitor.getResourceId());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,5 @@
-
+etcd:
+  url: http://localhost:2479
 server:
   port: 8081
 logging:

--- a/src/main/resources/application-vault.yml
+++ b/src/main/resources/application-vault.yml
@@ -1,0 +1,6 @@
+vault:
+  uri: http://localhost:8200
+  authentication: APPROLE
+#  app-role:
+#    role-id: or set env VAULT_APP_ROLE_ROLE_ID
+#    secret-id: or set set env VAULT_APP_ROLE_SECRET_ID

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,3 @@
-ambassador:
-  envoyRefreshInterval: PT10S
-etcd:
-  url: http://localhost:2479
 spring:
   resources:
     # disable serving of static web files since this is a REST/Actuator only web app

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
@@ -101,10 +101,18 @@ public class ConfigInstructionsBuilderTest {
     assertThat(telegrafConfig.getOperations(0).getId(), equalTo("00000000-0000-0001-0000-000000000000_r-1"));
     assertThat(telegrafConfig.getOperations(0).getType(), equalTo(Type.CREATE));
     assertThat(telegrafConfig.getOperations(0).getContent(), equalTo("content1"));
+    assertThat(telegrafConfig.getOperations(0).getExtraLabelsMap(), allOf(
+        hasEntry(BoundMonitorUtils.LABEL_MONITOR_ID, "00000000-0000-0001-0000-000000000000")
+        )
+    );
 
     assertThat(telegrafConfig.getOperations(1).getId(), equalTo("00000000-0000-0002-0000-000000000000_r-1"));
     assertThat(telegrafConfig.getOperations(1).getType(), equalTo(Type.MODIFY));
     assertThat(telegrafConfig.getOperations(1).getContent(), equalTo("content2"));
+    assertThat(telegrafConfig.getOperations(1).getExtraLabelsMap(), allOf(
+        hasEntry(BoundMonitorUtils.LABEL_MONITOR_ID, "00000000-0000-0002-0000-000000000000")
+        )
+    );
 
     assertThat(telegrafConfig.getOperations(2).getId(), equalTo("00000000-0000-0003-0000-000000000000_r-1"));
     assertThat(telegrafConfig.getOperations(2).getType(), equalTo(Type.REMOVE));
@@ -115,7 +123,8 @@ public class ConfigInstructionsBuilderTest {
     assertThat(telegrafConfig.getOperations(3).getContent(), equalTo("content5"));
     assertThat(telegrafConfig.getOperations(3).getExtraLabelsMap(), allOf(
         hasEntry(BoundMonitorUtils.LABEL_TARGET_TENANT, "t-1"),
-        hasEntry(BoundMonitorUtils.LABEL_RESOURCE, "r-2")
+        hasEntry(BoundMonitorUtils.LABEL_RESOURCE, "r-2"),
+        hasEntry(BoundMonitorUtils.LABEL_MONITOR_ID, "00000000-0000-0005-0000-000000000000")
         )
     );
 
@@ -126,5 +135,9 @@ public class ConfigInstructionsBuilderTest {
     assertThat(filebeatConfig.getOperations(0).getId(), equalTo("00000000-0000-0004-0000-000000000000_r-1"));
     assertThat(filebeatConfig.getOperations(0).getType(), equalTo(Type.CREATE));
     assertThat(filebeatConfig.getOperations(0).getContent(), equalTo("content4"));
+    assertThat(filebeatConfig.getOperations(0).getExtraLabelsMap(), allOf(
+        hasEntry(BoundMonitorUtils.LABEL_MONITOR_ID, "00000000-0000-0004-0000-000000000000")
+        )
+    );
   }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-362

# What

We needed a way to better correlate the metrics from Salus (telegraf -> Envoy -> Ambassador) to the original monitor that configured the collection of those metrics.

# How

Added the monitor ID as an extra tag to be given to telegraf when building its config file. As a result, the `collectionMetadata` of a salus metrics object in Kakfa now includes that identifier:

```json
{
  "timestamp": "2019-06-06T18:37:40Z",
  "accountType": "RCN",
  "account": "aaaaaa",
  "device": "development:0",
  "deviceLabel": "",
  "deviceMetadata": {
    "agent_discovered_arch": "amd64",
    "agent_discovered_hostname": "MS90HCG8WL",
    "pingable": "true",
    "agent_environment": "localdev",
    "agent_discovered_os": "darwin"
  },
  "monitoringSystem": "SALUS",
  "systemMetadata": {
    "envoyId": "16b589fc-888a-11e9-8826-6a00027f65d0"
  },
  "collectionName": "cpu",
  "collectionLabel": "",
  "collectionTarget": "",
  "collectionMetadata": {
    "monitor_id": "319af4e5-c96d-4cb6-9382-57ef46b8fb1a",
    "cpu": "cpu-total"
  },
  "ivalues": {},
  "fvalues": {
    "usage_guest": 0.0,
    "usage_steal": 0.0,
    "usage_system": 13.914239279909989,
    "usage_user": 8.463557944743092,
    "usage_idle": 77.62220277534692,
    "usage_irq": 0.0,
    "usage_softirq": 0.0,
    "usage_guest_nice": 0.0,
    "usage_iowait": 0.0,
    "usage_nice": 0.0
  },
  "svalues": {},
  "units": {}
}
```

## How to test

Unit test was updated