### PR TITLE
Provide logs for each GrpcConfig startup path

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfig.java
@@ -64,6 +64,9 @@ public class GrpcConfig extends GRpcServerBuilderConfigurer {
                 nettyServerBuilder
                         .sslContext(buildSslContext());
             }
+            else {
+                log.warn("gRPC TLS is DISABLED -- only suitable for local development");
+            }
 
         } catch (SSLException e) {
             throw new RuntimeException("Failed to initialize SSL context");
@@ -84,6 +87,11 @@ public class GrpcConfig extends GRpcServerBuilderConfigurer {
     }
 
     private SslContextBuilder buildSslContextFromProvided() {
+        log.info("Loading certificates from provided files: certChain={}, key={}, trustCert={}",
+            appProperties.getCertChainPath(),
+            appProperties.getKeyPath(),
+            appProperties.getTrustCertPath());
+
         return SslContextBuilder.forServer(
             new File(appProperties.getCertChainPath()),
             new File(appProperties.getKeyPath()))


### PR DESCRIPTION
# What

There was only a log statement in `GrpcConfig` for when it loaded the CA cert from Vault, so it's hard to tell when it goes down the other configuration paths.