### PR TITLE
Include resourceId in kafka routing/message key for metrics

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/KafkaEgress.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.services;
@@ -37,7 +35,7 @@ public class KafkaEgress {
         this.kafkaTopics = kafkaTopics;
     }
 
-    public void send(String tenantId, KafkaMessageType messageType, String payload) {
+    public void send(String routingKey, KafkaMessageType messageType, String payload) {
         final String topic;
         switch (messageType) {
             case METRIC:
@@ -51,6 +49,6 @@ public class KafkaEgress {
                     String.format("Unsupported messageType=%s for kafka routing", messageType));
         }
 
-        kafkaTemplate.send(topic, tenantId, payload);
+        kafkaTemplate.send(topic, routingKey, payload);
     }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
@@ -1,22 +1,22 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.services;
+
+import static com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder.buildMessageKeyFromParts;
 
 import com.rackspace.monplat.protocol.AccountType;
 import com.rackspace.monplat.protocol.ExternalMetric;
@@ -133,7 +133,10 @@ public class MetricRouter {
             jsonEncoder.flush();
 
             metricsRouted.increment();
-            kafkaEgress.send(tenantId, KafkaMessageType.METRIC, out.toString(StandardCharsets.UTF_8.name()));
+            kafkaEgress.send(
+                buildMessageKeyFromParts(tenantId, resourceId),
+                KafkaMessageType.METRIC, out.toString(StandardCharsets.UTF_8.name())
+            );
 
         } catch (IOException e) {
             log.warn("Failed to Avro encode avroMetric={} original={}", externalMetric, postedMetric, e);

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouterTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouterTest.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.services;
@@ -99,7 +97,7 @@ public class MetricRouterTest {
 
         verify(resourceLabelsService).getResourceLabels("t1", "r-1");
         verify(envoyRegistry).getResourceId("envoy-1");
-        verify(kafkaEgress).send("t1", KafkaMessageType.METRIC,
+        verify(kafkaEgress).send("t1:r-1", KafkaMessageType.METRIC,
             readContent("/MetricRouterTest/testRouteMetric.json"));
 
         verifyNoMoreInteractions(kafkaEgress, envoyRegistry);
@@ -125,6 +123,7 @@ public class MetricRouterTest {
                     .setName("cpu")
                     .putTags("cpu", "cpu1")
                     .putTags(BoundMonitorUtils.LABEL_TARGET_TENANT, "t-some-other")
+                    // simulate tenant's monitored resource "r-other"
                     .putTags(BoundMonitorUtils.LABEL_RESOURCE, "r-other")
                     .putFvalues("usage", 1.45)
                     .putSvalues("status", "enabled")
@@ -135,7 +134,7 @@ public class MetricRouterTest {
         metricRouter.route("t1", "envoy-1", postedMetric);
 
         verify(resourceLabelsService).getResourceLabels("t-some-other", "r-other");
-        verify(kafkaEgress).send("t-some-other", KafkaMessageType.METRIC,
+        verify(kafkaEgress).send("t-some-other:r-other", KafkaMessageType.METRIC,
             readContent("/MetricRouterTest/testRouteMetric_withTargetTenant.json"));
 
         verifyNoMoreInteractions(kafkaEgress, envoyRegistry);


### PR DESCRIPTION
# What

Before this change, only the tenant was being used as the kafka message/routing key, as seen here:

```
% Message on telemetry.metrics.json[0]@162 (key=1021059):
{"timestamp":"2019-06-19T20:25:50Z","accountType":"RCN","account":"1021059","device":"dev:geoff","deviceLabel":"","deviceMetadata":{"agent_discovered_arch":"amd64","agent_discovered_hostname":"MS90HCG8WL","agent_discovered_os":"darwin"},"monitoringSystem":"SALUS","systemMetadata":{"envoyId":"9c93207e-92cc-11e9-a512-6a00027f65d0"},"collectionName":"cpu","collectionLabel":"","collectionTarget":"","collectionMetadata":{"monitor_id":"3064bb9f-99cb-44e6-aed9-4465fd3dcafd","cpu":"cpu-total"},"ivalues":{},"fvalues":{"usage_system":12.804801800675254,"usage_irq":0.0,"usage_nice":0.0,"usage_softirq":0.0,"usage_steal":0.0,"usage_guest_nice":0.0,"usage_idle":74.40290108790796,"usage_iowait":0.0,"usage_user":12.792297111416781,"usage_guest":0.0},"svalues":{},"units":{}}
```

however, we have since standardized on including the resourceId to further distribute the load across kafka partitions.

## How to test

Affected unit tests have been updated