### PR TITLE
Add option for Google cloud logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,20 @@
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-etcd-adapter</artifactId>
             <version>0.1.0-SNAPSHOT</version>
+            <exclusions>
+                <!--
+                Let salus-telemetry-protocol dictate the gRPC version since Ambassador has
+                a direct use of gRPC.
+               -->
+                <exclusion>
+                    <artifactId>grpc-core</artifactId>
+                    <groupId>io.grpc</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>grpc-netty</artifactId>
+                    <groupId>io.grpc</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -75,7 +89,7 @@
         <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-protocol</artifactId>
-            <version>0.1.1</version>
+            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.monplat</groupId>
@@ -122,8 +136,9 @@
             <!-- for grpc tls support -->
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>2.0.18.Final</version>
+            <version>2.0.25.Final</version>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.vault</groupId>
             <artifactId>spring-vault-core</artifactId>
@@ -134,6 +149,24 @@
             <artifactId>micrometer-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-logging-logback</artifactId>
+            <version>0.96.0-alpha</version>
+            <exclusions>
+                <exclusion>
+                    <!--
+                    The shaded instance was registering
+                    io.grpc.netty.shaded.io.grpc.netty.NettyChannelProvider, which caused
+                    issues when our code tried to cast to io.grpc.netty.NettyChannelProvider.
+                    Excluding this didn't harm the google cloud logging since it was able to
+                    use the non-shaded instance.
+                    -->
+                    <artifactId>grpc-netty-shaded</artifactId>
+                    <groupId>io.grpc</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ZoneAuthorizer.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ZoneAuthorizer.java
@@ -21,12 +21,12 @@ import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
 import com.rackspace.salus.telemetry.ambassador.config.AmbassadorProperties;
 import com.rackspace.salus.telemetry.ambassador.types.ZoneNotAuthorizedException;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.ResourceAccessException;
-import java.util.List;
 
 /**
  * Handles validation and authorization of public zones.
@@ -91,7 +91,7 @@ public class ZoneAuthorizer {
       zones = zoneApi.getAvailableZones(tenantId);
     } catch (ResourceAccessException e) {
       // need to do something here to handle things more gracefully.
-      throw new RuntimeException("Unable to validate zones.");
+      throw new RuntimeException("Unable to validate zones.", e);
     }
     boolean found = zones.stream().anyMatch(z -> z.getName().equals(zone));
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,8 @@ spring:
           json:
             trusted:
               packages: com.rackspace.salus.telemetry.messaging
+  application:
+    name: salus-telemetry-ambassador
 management.endpoints.web.exposure.include: "health,jolokia,metrics"
 management:
   metrics:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,45 @@
+<!--
+  ~ Copyright 2019 Rackspace US, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+
+  <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="salus-app" />
+
+  <appender name="GCP" class="com.google.cloud.logging.logback.LoggingAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>DEBUG</level>
+    </filter>
+    <log>${APP_NAME}.log</log>
+    <flushLevel>WARN</flushLevel>
+  </appender>
+
+<!--  Console logging is active by default, but disable by activating no-console-logging profile -->
+  <springProfile name="!no-console-logging">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE" />
+    </root>
+  </springProfile>
+
+<!--  Add option for GCP logging -->
+  <springProfile name="gcp-logging">
+    <root level="INFO">
+      <appender-ref ref="GCP" />
+    </root>
+  </springProfile>
+
+</configuration>


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-440

# What

Uses [Spring Boot logging customization](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-logging.html#boot-features-logback-extensions) to add [Google cloud logging](https://cloud.google.com/logging/docs/setup/java) support.

GCP logging is off by default since it requires auth, so this PR introduces a Spring profile called `gcp-logging`.

Ambassador is the messiest one to change since it had a direct use of gRPC. The apps will have much simpler pom changes.

# Depends on

- https://github.com/racker/salus-telemetry-protocol/pull/9