### PR TITLE
Better logging and handling when lingering Envoys send metrics

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
-## How to test
+# How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
@@ -145,7 +145,10 @@ public class EnvoyAmbassadorService extends TelemetryAmbassadorGrpc.TelemetryAmb
             responseObserver.onNext(TelemetryEdge.KeepAliveResponse.newBuilder().build());
             responseObserver.onCompleted();
         } else {
-            log.warn("Failed keep alive due to unknown envoyId={}", envoyId);
+            // Can happen just after ambassador restart when the envoy TCP connection is held
+            // open by the load balancer. The onError will trigger the Envoy to tear down
+            // connection and re-connect.
+            log.warn("Failed to process keep alive due to unknown envoyId={}", envoyId);
             responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT));
         }
     }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
@@ -140,8 +140,7 @@ public class MetricRouter {
             metricsRouted.increment();
             kafkaEgress.send(tenantId, KafkaMessageType.METRIC, out.toString(StandardCharsets.UTF_8.name()));
 
-        } catch (IOException e) {
-//        } catch (IOException|NullPointerException e) {
+        } catch (IOException|NullPointerException e) {
             log.warn("Failed to Avro encode avroMetric={} original={}", externalMetric, postedMetric, e);
             throw new RuntimeException("Failed to Avro encode metric", e);
         }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.services;
@@ -90,6 +88,13 @@ public class MetricRouter {
         String resourceId = tagsMap.remove(BoundMonitorUtils.LABEL_RESOURCE);
         if (resourceId == null) {
             resourceId = envoyRegistry.getResourceId(envoyId);
+
+            if (resourceId == null) {
+                log.warn("Unable to locate resourceId while routing"
+                        + " measurement={} for tenant={} envoy={} tags={}",
+                    nameTagValue.getName(), tenantId, envoyId, nameTagValue.getTagsMap());
+                return;
+            }
         }
 
         final String taggedTargetTenant = tagsMap.remove(BoundMonitorUtils.LABEL_TARGET_TENANT);
@@ -136,6 +141,7 @@ public class MetricRouter {
             kafkaEgress.send(tenantId, KafkaMessageType.METRIC, out.toString(StandardCharsets.UTF_8.name()));
 
         } catch (IOException e) {
+//        } catch (IOException|NullPointerException e) {
             log.warn("Failed to Avro encode avroMetric={} original={}", externalMetric, postedMetric, e);
             throw new RuntimeException("Failed to Avro encode metric", e);
         }

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouterTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouterTest.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.services;
@@ -138,6 +136,37 @@ public class MetricRouterTest {
         verify(kafkaEgress).send("t-some-other", KafkaMessageType.METRIC,
             readContent("/MetricRouterTest/testRouteMetric_withTargetTenant.json"));
 
+        verifyNoMoreInteractions(kafkaEgress, envoyRegistry);
+    }
+
+    @Test
+    public void testRouteMetric_invalid_noResourceId() {
+        Map<String, String> envoyLabels = new HashMap<>();
+        envoyLabels.put("hostname", "host1");
+        envoyLabels.put("os", "linux");
+
+        when(resourceLabelsService.getResourceLabels(any(), any()))
+            .thenReturn(envoyLabels);
+
+        when(envoyRegistry.getResourceId(any()))
+            // induce the scenario
+            .thenReturn(null);
+
+        final TelemetryEdge.PostedMetric postedMetric = TelemetryEdge.PostedMetric.newBuilder()
+            .setMetric(TelemetryEdge.Metric.newBuilder()
+                .setNameTagValue(TelemetryEdge.NameTagValueMetric.newBuilder()
+                    .setTimestamp(1539030613123L)
+                    .setName("cpu")
+                    .putTags("cpu", "cpu1")
+                    .putFvalues("usage", 1.45)
+                    .putSvalues("status", "enabled")
+                    .build())
+            )
+            .build();
+
+        metricRouter.route("t-1", "e-1", postedMetric);
+
+        verify(envoyRegistry).getResourceId("e-1");
         verifyNoMoreInteractions(kafkaEgress, envoyRegistry);
     }
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-470

# What

From the jira issue, the following logs seem to indicate the GKE LB allowed the Envoy's TCP connection to stay alive, so the Envoy happily sent keep alive and metrics to what it thought was its Ambassador but after redeploy the new Ambassador got these gRPC operations.

```
WARN 1 --- [ault-executor-1] c.r.s.t.e.services.EnvoyLeaseTracking    : Did not have lease for envoyInstanceId=9e44aa49-9924-11e9-8c96-842b2b1801db
--
WARN 1 --- [ault-executor-1] c.r.s.t.a.s.EnvoyAmbassadorService       : Failed keep alive due to unknown envoyId=9e44aa49-9924-11e9-8c96-842b2b1801db
WARN 1 --- [ault-executor-0] c.r.s.t.a.services.MetricRouter          : No resource labels are being tracked for tenant=646398 resource=null
java.lang.NullPointerException: null of string of com.rackspace.monplat.protocol.ExternalMetric
at org.apache.avro.generic.GenericDatumWriter.npe(GenericDatumWriter.java:145) ~[avro-1.8.2.jar:1.8.2]
at org.apache.avro.generic.GenericDatumWriter.writeWithoutConversion(GenericDatumWriter.java:139) ~[avro-1.8.2.jar:1.8.2]
at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:75) ~[avro-1.8.2.jar:1.8.2]
at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:62) ~[avro-1.8.2.jar:1.8.2]
at com.rackspace.salus.telemetry.ambassador.services.MetricRouter.route(MetricRouter.java:132) ~[classes/:na]
```

# How

There might be even more robust checks we can do to ensure an Ambassador restart is detected properly by the Envoy, but perhaps not due to the load balancer in between. That is actually why the periodic keep alive was included as a catch all for these scenarios.

I tweaked one of those log messages to clarify the direction of the keep alive better and the metric routing handles the lack of resource ID lookup better.

## How to test

Added a new unit test