### PR TITLE
Use default jib base image, which is now non-Alpine anyway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,17 +219,6 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <configuration>
-                    <from>
-                        <!--
-                        Unable to use openjdk alpine base due to
-                        java.lang.UnsatisfiedLinkError: /tmp/libnetty_tcnative_linux_x86_646515749084901402865.so: Error loading shared library libcrypt.so.1: No such file or directory
-                        -->
-                        <!-- non-alpine openjdk base has even more vulnerabilities than distroless one -->
-                        <!-- SHA can be obtained from https://console.cloud.google.com/gcr/images/distroless/GLOBAL/java?gcrImageListsize=50 -->
-                        <image>gcr.io/distroless/java@sha256:b430543bea1d8326e767058bdab3a2482ea45f59d7af5c5c61334cd29ede88a1</image>
-                    </from>
-                </configuration>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
# What

The code with built with Java 11 now, so this app's base image was incompatible.

# How

As of https://github.com/racker/salus-app-base/pull/13 the base image is Java 11 and non-Alpine, so that default will work well across all of our applications now.

## How to test

Do a local docker build and confirm the container is able to startup properly (ignoring application level connectivity issues):

```
export SHORT_SHA=HEAD
mvn package jib:dockerBuild -DskipTests=true
docker run -it --rm racker/salus-telemetry-ambassador
```