### PR TITLE
Upgrade salus-telemetry-protocol to align grpc with jetcd 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-protocol</artifactId>
-            <version>0.1.1</version>
+            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.monplat</groupId>

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ZoneAuthorizer.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ZoneAuthorizer.java
@@ -21,12 +21,12 @@ import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
 import com.rackspace.salus.telemetry.ambassador.config.AmbassadorProperties;
 import com.rackspace.salus.telemetry.ambassador.types.ZoneNotAuthorizedException;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.ResourceAccessException;
-import java.util.List;
 
 /**
  * Handles validation and authorization of public zones.
@@ -91,7 +91,7 @@ public class ZoneAuthorizer {
       zones = zoneApi.getAvailableZones(tenantId);
     } catch (ResourceAccessException e) {
       // need to do something here to handle things more gracefully.
-      throw new RuntimeException("Unable to validate zones.");
+      throw new RuntimeException("Unable to validate zones.", e);
     }
     boolean found = zones.stream().anyMatch(z -> z.getName().equals(zone));
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-474

# What

The upgrade of jetcd to 0.3.0 in common and etcd-adapter causes the following Maven dependency resolution issue:

```
[ERROR] Failed to execute goal on project salus-telemetry-resource-management: Could not resolve dependencies for project com.rackspace.salus:salus-telemetry-resource-management:jar:0.0.1-SNAPSHOT: Failed to collect dependencies for com.rackspace.salus:salus-telemetry-resource-management:jar:0.0.1-SNAPSHOT: Could not resolve version conflict among [com.rackspace.salus:salus-telemetry-protocol:jar:0.2-SNAPSHOT -> io.grpc:grpc-netty:jar:1.15.0 -> io.grpc:grpc-core:jar:[1.15.0,1.15.0], com.rackspace.salus:salus-telemetry-protocol:jar:0.2-SNAPSHOT -> io.grpc:grpc-protobuf:jar:1.15.0 -> io.grpc:grpc-core:jar:1.15.0, com.rackspace.salus:salus-telemetry-protocol:jar:0.2-SNAPSHOT -> io.grpc:grpc-protobuf:jar:1.15.0 -> io.grpc:grpc-protobuf-lite:jar:1.15.0 -> io.grpc:grpc-core:jar:1.15.0, com.rackspace.salus:salus-telemetry-protocol:jar:0.2-SNAPSHOT -> io.grpc:grpc-stub:jar:1.15.0 -> io.grpc:grpc-core:jar:1.15.0, com.rackspace.salus:salus-telemetry-model:jar:0.1.0-SNAPSHOT -> com.rackspace.salus:salus-common:jar:0.1.0-SNAPSHOT -> io.etcd:jetcd-core:jar:0.3.0 -> io.etcd:jetcd-common:jar:0.3.0 -> io.grpc:grpc-core:jar:1.17.1, com.rackspace.salus:salus-telemetry-model:jar:0.1.0-SNAPSHOT -> com.rackspace.salus:salus-common:jar:0.1.0-SNAPSHOT -> io.etcd:jetcd-core:jar:0.3.0 -> io.etcd:jetcd-resolver:jar:0.3.0 -> io.grpc:grpc-core:jar:1.17.1, com.rackspace.salus:salus-telemetry-model:jar:0.1.0-SNAPSHOT -> com.rackspace.salus:salus-common:jar:0.1.0-SNAPSHOT -> io.etcd:jetcd-core:jar:0.3.0 -> io.grpc:grpc-core:jar:1.17.1, com.rackspace.salus:salus-telemetry-model:jar:0.1.0-SNAPSHOT -> com.rackspace.salus:salus-common:jar:0.1.0-SNAPSHOT -> io.etcd:jetcd-core:jar:0.3.0 -> io.grpc:grpc-grpclb:jar:1.17.1 -> io.grpc:grpc-core:jar:[1.17.1,1.17.1]] -> [Help 1]
``` 

Which boils down to a conflict of `grpc-core` versions `1.17.1` and `1.15.0`.

# How

Upgrade salus-telemetry-protocol, which includes an upgrade of grpc that aligns with jetcd 0.3.0

# How to test

Ensure build and exist unit tests succeed

# Depends on

- https://github.com/racker/salus-telemetry-protocol/pull/11