### PR TITLE
 Rename resourceTenant to tenantId 

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
@@ -66,7 +66,7 @@ public class ConfigInstructionsBuilder {
     opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_MONITOR_ID, boundMonitor.getMonitorId().toString());
 
     if (isRemoteMonitor(boundMonitor)) {
-      opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_TARGET_TENANT, boundMonitor.getResourceTenant());
+      opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_TARGET_TENANT, boundMonitor.getTenantId());
       opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_RESOURCE, boundMonitor.getResourceId());
     }
 

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -116,7 +116,7 @@ public class EnvoyRegistry {
 
   private static ResourceKey buildResourceKey(BoundMonitorDTO boundMonitorDTO) {
     return new ResourceKey(
-        boundMonitorDTO.getResourceTenant(), boundMonitorDTO.getResourceId());
+        boundMonitorDTO.getTenantId(), boundMonitorDTO.getResourceId());
   }
 
   /**
@@ -389,7 +389,7 @@ public class EnvoyRegistry {
               new BoundMonitorEntry(
                   hashRenderedContent(boundMonitor), boundMonitor.getAgentType(),
                   boundMonitor.getMonitorId(),
-                  boundMonitor.getResourceTenant(), boundMonitor.getResourceId()
+                  boundMonitor.getTenantId(), boundMonitor.getResourceId()
               )
           );
         } else {
@@ -405,7 +405,7 @@ public class EnvoyRegistry {
                 new BoundMonitorEntry(
                     hashRenderedContent(boundMonitor), boundMonitor.getAgentType(),
                     boundMonitor.getMonitorId(),
-                    boundMonitor.getResourceTenant(), boundMonitor.getResourceId()
+                    boundMonitor.getTenantId(), boundMonitor.getResourceId()
                 )
             );
           }
@@ -420,7 +420,7 @@ public class EnvoyRegistry {
             new BoundMonitorDTO()
                 .setAgentType(removed.agentType)
                 .setMonitorId(removed.monitorId)
-                .setResourceTenant(removed.resourceTenantId)
+                .setTenantId(removed.tenantId)
                 .setResourceId(removed.resourceId)
                 // rendered content is not used by envoy, but needs to be non-null for gRPC
                 .setRenderedContent("")
@@ -497,7 +497,7 @@ public class EnvoyRegistry {
     /**
      * The tenant owning the resource. Needed to handle deletion of entries.
      */
-    final String resourceTenantId;
+    final String tenantId;
     /**
      * resourceId is needed to handle deletion of entries.
      */

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
@@ -51,6 +51,7 @@ public class ConfigInstructionsBuilderTest {
     builder.add(
         new BoundMonitorDTO()
             .setAgentType(TELEGRAF)
+            .setTenantId("t-1")
             .setRenderedContent("content1")
             .setMonitorId(m1)
             .setResourceId("r-1"),
@@ -59,6 +60,7 @@ public class ConfigInstructionsBuilderTest {
     builder.add(
         new BoundMonitorDTO()
             .setAgentType(TELEGRAF)
+            .setTenantId("t-1")
             .setRenderedContent("content2")
             .setMonitorId(m2)
             .setResourceId("r-1"),
@@ -67,6 +69,7 @@ public class ConfigInstructionsBuilderTest {
     builder.add(
         new BoundMonitorDTO()
             .setAgentType(TELEGRAF)
+            .setTenantId("t-1")
             .setRenderedContent("")
             .setMonitorId(m3)
             .setResourceId("r-1"),
@@ -75,6 +78,7 @@ public class ConfigInstructionsBuilderTest {
     builder.add(
         new BoundMonitorDTO()
             .setAgentType(FILEBEAT)
+            .setTenantId("t-1")
             .setRenderedContent("content4")
             .setMonitorId(m4)
             .setResourceId("r-1"),
@@ -85,7 +89,7 @@ public class ConfigInstructionsBuilderTest {
             .setAgentType(TELEGRAF)
             .setRenderedContent("content5")
             .setMonitorId(m5)
-            .setResourceTenant("t-1")
+            .setTenantId("t-1")
             .setResourceId("r-2")
             .setZoneName("z-1"),
         OperationType.CREATE

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -291,18 +291,18 @@ public class EnvoyRegistryTest {
       final List<BoundMonitorDTO> boundMonitors = Arrays.asList(
           new BoundMonitorDTO()
               .setMonitorId(id1)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-1")
               .setRenderedContent("{\"instance\":1, \"state\":1}"),
           new BoundMonitorDTO()
               .setMonitorId(id2)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-2")
               .setAgentType(AgentType.TELEGRAF)
               .setRenderedContent("{\"instance\":2, \"state\":1}"),
           new BoundMonitorDTO()
               .setMonitorId(id3)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setZoneName("z-1")
               .setResourceId("r-3")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
@@ -310,7 +310,7 @@ public class EnvoyRegistryTest {
           new BoundMonitorDTO()
               .setMonitorId(id3)
               .setZoneName("z-1")
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-4")
               .setRenderedContent("{\"instance\":3, \"state\":1}")
       );
@@ -330,40 +330,40 @@ public class EnvoyRegistryTest {
           // id1 MODIFIED
           new BoundMonitorDTO()
               .setMonitorId(id1)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-1")
               .setRenderedContent("{\"instance\":1, \"state\":2}"),
           // id2 REMOVED
           // id3, r-3 UNCHANGED
           new BoundMonitorDTO()
               .setMonitorId(id3)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setZoneName("z-1")
               .setResourceId("r-3")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
           // id3, r-4 UNCHANGED
           new BoundMonitorDTO()
               .setMonitorId(id3)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setZoneName("z-1")
               .setResourceId("r-4")
               .setRenderedContent("{\"instance\":3, \"state\":1}"),
           // id4, r-5 CREATED
           new BoundMonitorDTO()
               .setMonitorId(id4)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-5")
               .setRenderedContent("{\"instance\":4, \"state\":1}"),
           // id5, r-5 CREATED to confirm resource label tracked only once per binding event
           new BoundMonitorDTO()
               .setMonitorId(id5)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-5")
               .setRenderedContent("{\"instance\":5, \"state\":1}"),
           // id5, r-1 CREATED to confirm resource label re-tracked on this binding event
           new BoundMonitorDTO()
               .setMonitorId(id5)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-1")
               .setRenderedContent("{\"instance\":6, \"state\":1}")
   );
@@ -375,31 +375,31 @@ public class EnvoyRegistryTest {
       assertThat(changes.get(OperationType.CREATE), containsInAnyOrder(
           new BoundMonitorDTO()
               .setMonitorId(id4)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-5")
               .setRenderedContent("{\"instance\":4, \"state\":1}"),
           new BoundMonitorDTO()
               .setMonitorId(id5)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-5")
               .setRenderedContent("{\"instance\":5, \"state\":1}"),
           new BoundMonitorDTO()
               .setMonitorId(id5)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-1")
               .setRenderedContent("{\"instance\":6, \"state\":1}")
       ));
       assertThat(changes.get(OperationType.UPDATE), contains(
           new BoundMonitorDTO()
               .setMonitorId(id1)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-1")
               .setRenderedContent("{\"instance\":1, \"state\":2}")
       ));
       assertThat(changes.get(OperationType.DELETE), contains(
           new BoundMonitorDTO()
               .setMonitorId(id2)
-              .setResourceTenant("t-1")
+              .setTenantId("t-1")
               .setResourceId("r-2")
               .setAgentType(AgentType.TELEGRAF)
               // rendered content is not used by envoy, but needs to be non-null for gRPC

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/KafkaEgressTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/KafkaEgressTest.java
@@ -104,7 +104,7 @@ public class KafkaEgressTest {
     );
 
     embeddedKafka.consumeFromEmbeddedTopics(consumer, TOPIC_METRICS);
-    final ConsumerRecord<String, String> record = getSingleRecord(consumer, TOPIC_METRICS, 500);
+    final ConsumerRecord<String, String> record = getSingleRecord(consumer, TOPIC_METRICS, 1000);
 
     // Use Hamcrest matchers provided by spring-kafka-test
     // https://docs.spring.io/spring-kafka/docs/2.2.4.RELEASE/reference/#hamcrest-matchers

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MonitorEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MonitorEventListenerTest.java
@@ -93,13 +93,13 @@ public class MonitorEventListenerTest {
         .setMonitorId(id1)
         .setResourceId("r-1")
         .setAgentType(AgentType.TELEGRAF)
-        .setResourceTenant("t-1")
+        .setTenantId("t-1")
         .setRenderedContent("content1"),
         new BoundMonitorDTO()
         .setMonitorId(id2)
         .setResourceId("r-2")
         .setAgentType(AgentType.FILEBEAT)
-        .setResourceTenant("t-2")
+        .setTenantId("t-2")
         .setRenderedContent("content2")
     );
 


### PR DESCRIPTION
# What

Uses tenantId from Bound Monitors instead of resourceTenant

I also had to bump a timeout for a test that kept failing for me.

# How

Rename the field.

# Why

I kept getting confused by `resourceTenant` and whether it related to the tenant of the resource to be monitored or the tenant of the resource that would do the monitoring (for public zones).

Using `tenantId` on the Bound Monitor object seems clearer to me since a bound monitor is only tied to one tenant, the customer id.  It can move between envoy ids for public/private pollers, but it is still only ever tied to one tenant in the db.

`resourceTenant` was only included on the DTO, but now `tenantId` is on the entity https://github.com/racker/salus-telemetry-model/pull/63