### PR TITLE
Add support for test-monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorEventListener.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorEventListener.java
@@ -39,7 +39,7 @@ public class TestMonitorEventListener {
   @Autowired
   public TestMonitorEventListener(EnvoyRegistry envoyRegistry,
                                   KafkaTopicProperties kafkaTopicProperties,
-                                  @Value("${spring.application.name") String appName,
+                                  @Value("${spring.application.name}") String appName,
                                   @Value("${localhost.name}") String ourHostName) {
     this.envoyRegistry = envoyRegistry;
     this.kafkaTopicProperties = kafkaTopicProperties;

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorEventListener.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorEventListener.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.ambassador.services;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.services.TelemetryEdge;
+import com.rackspace.salus.services.TelemetryEdge.EnvoyInstruction;
+import com.rackspace.salus.services.TelemetryEdge.EnvoyInstructionTestMonitor;
+import com.rackspace.salus.telemetry.messaging.TestMonitorRequestEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class TestMonitorEventListener {
+
+  private final EnvoyRegistry envoyRegistry;
+  private final KafkaTopicProperties kafkaTopicProperties;
+  private final String appName;
+  private final String ourHostName;
+
+  @Autowired
+  public TestMonitorEventListener(EnvoyRegistry envoyRegistry,
+                                  KafkaTopicProperties kafkaTopicProperties,
+                                  @Value("${spring.application.name") String appName,
+                                  @Value("${localhost.name}") String ourHostName) {
+    this.envoyRegistry = envoyRegistry;
+    this.kafkaTopicProperties = kafkaTopicProperties;
+    this.appName = appName;
+    this.ourHostName = ourHostName;
+  }
+
+  @SuppressWarnings("unused") // in @KafkaListener SpEL
+  public String getTopic() {
+    return kafkaTopicProperties.getTestMonitorRequests();
+  }
+
+  @SuppressWarnings("unused") // in @KafkaListener SpEL
+  public String getGroupId() {
+    return String.join("-", appName, "testMonitors", ourHostName);
+  }
+
+  @KafkaListener(topics = "#{__listener.topic}", groupId = "#{__listener.groupId}")
+  public void consumeTestMonitorEvent(TestMonitorRequestEvent event) {
+    final String envoyId = event.getEnvoyId();
+
+    if (!envoyRegistry.contains(envoyId)) {
+      log.trace("Discarded testMonitorEvent={} for unregistered Envoy", event);
+      return;
+    }
+
+    log.debug("Handling testMonitorEvent={}", event);
+
+    EnvoyInstruction testMonitorInstruction = EnvoyInstruction.newBuilder()
+        .setTestMonitor(
+            EnvoyInstructionTestMonitor.newBuilder()
+                .setAgentType(TelemetryEdge.AgentType.valueOf(event.getAgentType().name()))
+                .setCorrelationId(event.getCorrelationId())
+                .setContent(event.getRenderedContent())
+        )
+        .build();
+    envoyRegistry.sendInstruction(envoyId, testMonitorInstruction);
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorResultsProducer.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorResultsProducer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.ambassador.services;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.services.TelemetryEdge.Metric;
+import com.rackspace.salus.services.TelemetryEdge.NameTagValueMetric;
+import com.rackspace.salus.services.TelemetryEdge.TestMonitorResults;
+import com.rackspace.salus.telemetry.messaging.TestMonitorResultsEvent;
+import com.rackspace.salus.telemetry.model.SimpleNameTagValueMetric;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestMonitorResultsProducer {
+
+  private final KafkaTopicProperties kafkaTopicProperties;
+  private final KafkaTemplate kafkaTemplate;
+
+  @Autowired
+  public TestMonitorResultsProducer(KafkaTopicProperties kafkaTopicProperties,
+                                    KafkaTemplate kafkaTemplate) {
+    this.kafkaTopicProperties = kafkaTopicProperties;
+    this.kafkaTemplate = kafkaTemplate;
+  }
+
+  public void send(TestMonitorResults results) {
+    final TestMonitorResultsEvent event = new TestMonitorResultsEvent()
+        .setCorrelationId(results.getCorrelationId())
+        .setErrors(results.getErrorsList())
+        .setMetrics(convertMetrics(results.getMetricsList()));
+
+    //noinspection unchecked
+    kafkaTemplate.send(kafkaTopicProperties.getTestMonitorResults(), event);
+  }
+
+  private List<SimpleNameTagValueMetric> convertMetrics(List<Metric> envoyMetrics) {
+    return envoyMetrics.stream()
+        .map(metric -> {
+          final NameTagValueMetric ntv = metric.getNameTagValue();
+          return new SimpleNameTagValueMetric()
+                  .setName(ntv.getName())
+                  .setTags(ntv.getTagsMap())
+                  .setIvalues(ntv.getIvaluesMap())
+                  .setFvalues(ntv.getFvaluesMap())
+                  .setSvalues(ntv.getSvaluesMap());
+            }
+        )
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,8 @@ spring:
           json:
             trusted:
               packages: com.rackspace.salus.telemetry.messaging
+  application:
+    name: salus-telemetry-ambassador
 management.endpoints.web.exposure.include: "health,jolokia,metrics"
 management:
   metrics:

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorServiceTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.ambassador.services;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.rackspace.salus.services.TelemetryEdge.Metric;
+import com.rackspace.salus.services.TelemetryEdge.NameTagValueMetric;
+import com.rackspace.salus.services.TelemetryEdge.PostTestMonitorResultsResponse;
+import com.rackspace.salus.services.TelemetryEdge.TestMonitorResults;
+import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class EnvoyAmbassadorServiceTest {
+
+  @Configuration
+  @Import({EnvoyAmbassadorService.class})
+  public static class TestConfig {
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+      return new SyncTaskExecutor();
+    }
+
+    @Bean
+    public MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
+    }
+  }
+
+  @Autowired
+  EnvoyAmbassadorService envoyAmbassadorService;
+
+  @MockBean
+  EnvoyRegistry envoyRegistry;
+
+  @MockBean
+  LogEventRouter logEventRouter;
+
+  @MockBean
+  MetricRouter metricRouter;
+
+  @MockBean
+  TestMonitorResultsProducer testMonitorResultsProducer;
+
+  @Test
+  public void testPostTestMonitorResults_success() {
+    @SuppressWarnings("unchecked") final StreamObserver<PostTestMonitorResultsResponse> respStreamObserver = mock(
+        StreamObserver.class);
+
+    final TestMonitorResults expectedResults = TestMonitorResults.newBuilder()
+        .setCorrelationId("id-1")
+        .addErrors("error-1")
+        .addMetrics(Metric.newBuilder()
+            .setNameTagValue(
+                NameTagValueMetric.newBuilder()
+                    .setName("metric name")
+                    .putIvalues("count", 4)
+                    .build()
+            )
+            .build())
+        .build();
+
+    envoyAmbassadorService.postTestMonitorResults(
+        expectedResults,
+        respStreamObserver
+    );
+
+    verify(testMonitorResultsProducer).send(expectedResults);
+
+    verify(respStreamObserver).onNext(notNull());
+    verify(respStreamObserver).onCompleted();
+
+    verifyNoMoreInteractions(testMonitorResultsProducer, respStreamObserver);
+  }
+
+  @Test
+  public void testPostTestMonitorResults_exceptionDuringHandler() {
+
+    doThrow(new IllegalStateException("fake failure"))
+        .when(testMonitorResultsProducer)
+        .send(any());
+
+    @SuppressWarnings("unchecked")
+    final StreamObserver<PostTestMonitorResultsResponse> respStreamObserver = mock(
+        StreamObserver.class);
+
+    final TestMonitorResults expectedResults = TestMonitorResults.newBuilder()
+        .setCorrelationId("id-1")
+        .addErrors("error-1")
+        .addMetrics(Metric.newBuilder()
+            .setNameTagValue(
+                NameTagValueMetric.newBuilder()
+                    .setName("metric name")
+                    .putIvalues("count", 4)
+                    .build()
+            )
+            .build())
+        .build();
+
+    envoyAmbassadorService.postTestMonitorResults(
+        expectedResults,
+        respStreamObserver
+    );
+
+    verify(testMonitorResultsProducer).send(expectedResults);
+
+    // still does the same onNext/complete without an error to avoid circular feedback
+    verify(respStreamObserver).onNext(notNull());
+    verify(respStreamObserver).onCompleted();
+
+    verifyNoMoreInteractions(testMonitorResultsProducer, respStreamObserver);
+  }
+}

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorEventListenerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.ambassador.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.services.TelemetryEdge;
+import com.rackspace.salus.telemetry.messaging.TestMonitorRequestEvent;
+import com.rackspace.salus.telemetry.model.AgentType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TestMonitorEventListenerTest {
+
+  @Configuration
+  @Import({TestMonitorEventListener.class, KafkaTopicProperties.class})
+  public static class TestConfig {
+
+  }
+
+  @MockBean
+  EnvoyRegistry envoyRegistry;
+
+  @Autowired
+  TestMonitorEventListener testMonitorEventListener;
+
+  @Test
+  public void testConsumeTestMonitorEvent_contains() {
+
+    when(envoyRegistry.contains(any()))
+        .thenReturn(true);
+
+    // EXECUTE
+
+    testMonitorEventListener.consumeTestMonitorEvent(
+        new TestMonitorRequestEvent()
+            .setCorrelationId("id-1")
+            .setTenantId("t-1")
+            .setResourceId("r-1")
+            .setEnvoyId("e-1")
+            .setAgentType(AgentType.TELEGRAF)
+            .setRenderedContent("content-1")
+    );
+
+    // VERIFY
+
+    verify(envoyRegistry).contains("e-1");
+
+    verify(envoyRegistry).sendInstruction(eq("e-1"), argThat(envoyInstruction -> {
+      assertThat(envoyInstruction.getTestMonitor()).isNotNull();
+      assertThat(envoyInstruction.getTestMonitor().getCorrelationId()).isEqualTo("id-1");
+      assertThat(envoyInstruction.getTestMonitor().getContent()).isEqualTo("content-1");
+      assertThat(envoyInstruction.getTestMonitor().getAgentType())
+          .isEqualTo(TelemetryEdge.AgentType.TELEGRAF);
+
+      return true;
+    }));
+
+    verifyNoMoreInteractions(envoyRegistry);
+  }
+
+  @Test
+  public void testConsumeTestMonitorEvent_doesNotContain() {
+
+    when(envoyRegistry.contains(any()))
+        .thenReturn(false);
+
+    // EXECUTE
+
+    testMonitorEventListener.consumeTestMonitorEvent(
+        new TestMonitorRequestEvent()
+            .setCorrelationId("id-1")
+            .setTenantId("t-1")
+            .setResourceId("r-1")
+            .setEnvoyId("e-1")
+            .setAgentType(AgentType.TELEGRAF)
+            .setRenderedContent("content-1")
+    );
+
+    // VERIFY
+
+    verify(envoyRegistry).contains("e-1");
+
+    // sendInstruction not called
+
+    verifyNoMoreInteractions(envoyRegistry);
+  }
+}

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorResultsProducerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorResultsProducerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.ambassador.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.services.TelemetryEdge;
+import com.rackspace.salus.services.TelemetryEdge.TestMonitorResults;
+import com.rackspace.salus.telemetry.messaging.TestMonitorResultsEvent;
+import com.rackspace.salus.telemetry.model.SimpleNameTagValueMetric;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TestMonitorResultsProducerTest {
+
+  @Configuration
+  @Import({TestMonitorResultsProducer.class})
+  public static class TestConfig {
+
+    @Bean
+    public KafkaTopicProperties kafkaTopicProperties() {
+      final KafkaTopicProperties properties = new KafkaTopicProperties();
+      properties.setTestMonitorResults("results-topic");
+      return properties;
+    }
+  }
+
+  @MockBean
+  KafkaTemplate kafkaTemplate;
+
+  @Autowired
+  TestMonitorResultsProducer testMonitorResultsProducer;
+
+  @Test
+  public void testSend() {
+    testMonitorResultsProducer.send(
+        TestMonitorResults.newBuilder()
+            .setCorrelationId("id-1")
+            .addErrors("an error")
+            .addMetrics(
+                TelemetryEdge.Metric.newBuilder()
+                    .setNameTagValue(TelemetryEdge.NameTagValueMetric.newBuilder()
+                        .setName("cpu")
+                        .putTags("tag-1", "value-1")
+                        .putIvalues("count", 3)
+                        .putFvalues("usage", 5.67)
+                        .putSvalues("available", "true")
+                        .build())
+                    .build()
+            )
+            .build()
+    );
+
+    //noinspection unchecked
+    verify(kafkaTemplate).send(eq("results-topic"), argThat(o -> {
+      assertThat(o).isInstanceOf(TestMonitorResultsEvent.class);
+
+      final TestMonitorResultsEvent event = (TestMonitorResultsEvent) o;
+      assertThat(event.getCorrelationId()).isEqualTo("id-1");
+      assertThat(event.getErrors()).containsExactly("an error");
+      assertThat(event.getMetrics()).containsExactly(
+          new SimpleNameTagValueMetric()
+          .setName("cpu")
+          .setTags(Map.of("tag-1", "value-1"))
+          .setFvalues(Map.of("usage", 5.67))
+          .setIvalues(Map.of("count", 3L))
+          .setSvalues(Map.of("available", "true"))
+      );
+
+      return true;
+    }));
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-564

# What

Adds support
- translating a test-monitor request event into an instruction to an attached Envoy (or ignoring if not attached)
- translating the posted test results and the metrics contained within to a test-monitor results event

# How to test

Unit tests added