### PR TITLE
add influx and fluency clients

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,13 +18,7 @@ management.endpoints.web.exposure.include: "health,jolokia,metrics"
 management:
   metrics:
     export:
-      statsd:
-        flavor: ${statsd.flavor:telegraf}
-        host: ${statsd.host:localhost}
-        port: ${statsd.port:8125}
-        enabled: ${statsd.enabled:false}
       influx:
-        db: telemetry-ambassador
-        host: ${statsd.host:localhost}
-        port: ${statsd.port:8086}
-        enabled: ${influx.enabled:false}
+        uri: ${salus.metrics.influx.uri:http://localhost:8086}
+        db: salus
+        enabled: ${salus.metrics.influx.enabled:false}

--- a/src/main/resources/logback-fluency.xml
+++ b/src/main/resources/logback-fluency.xml
@@ -1,0 +1,55 @@
+<!--
+  ~ Copyright 2019 Rackspace US, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<included>
+  <springProperty scope="context" name="SALUS_FLUENTD_HOST" source="salus.fluentd.host"
+    defaultValue="localhost"/>
+  <springProperty scope="context" name="SALUS_FLUENTD_PORT" source="salus.fluentd.port"
+    defaultValue="24224"/>
+  <springProperty scope="context" name="SALUS_FLUENTD_QUEUESIZE" source="salus.fluentd.queue-size"
+    defaultValue="999"/>
+  <springProperty scope="context" name="SALUS_FLUENTD_NEVERBLOCK" source="salus.fluentd.never-block"
+    defaultValue="true"/>
+
+  <springProperty scope="context" name="SALUS_FLUENTD_MAXFLUSHTIME" source="salus.fluentd.max-flush-time"
+    defaultValue="10000"/>
+
+  <appender name="FLUENCY_SYNC" class="ch.qos.logback.more.appenders.FluencyLogbackAppender">
+    <tag>salus</tag>
+
+    <!-- Host name/address and port number which Flentd placed -->
+    <remoteHost>${SALUS_FLUENTD_HOST}</remoteHost>
+    <port>${SALUS_FLUENTD_PORT}</port>
+
+    <encoder>
+      <pattern><![CDATA[%date{HH:mm:ss.SSS} [%thread] %-5level %logger{15}#%line %msg]]></pattern>
+    </encoder>
+  </appender>
+
+  <appender name="FLUENCY" class="ch.qos.logback.classic.AsyncAppender">
+    <!-- Max queue size of logs which is waiting to be sent (When it reach to the max size, the log will be disappeared). -->
+    <queueSize>${SALUS_FLUENTD_QUEUESIZE}</queueSize>
+    <!-- Never block when the queue becomes full. -->
+    <neverBlock>${SALUS_FLUENTD_NEVERBLOCK}</neverBlock>
+    <!-- The default maximum queue flush time allowed during appender stop.
+         If the worker takes longer than this time it will exit, discarding any remaining items in the queue.
+         10000 millis
+     -->
+    <maxFlushTime>${SALUS_FLUENTD_MAXFLUSHTIME}</maxFlushTime>
+    <appender-ref ref="FLUENCY_SYNC" />
+  </appender>
+
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Rackspace US, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+
+<configuration>
+
+  <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+  <include resource="logback-fluency.xml" />
+
+  
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern><![CDATA[%date{HH:mm:ss.SSS} [%thread] %-5level %logger{15}#%line %msg%n]]></pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <springProfile name="production">
+      <appender-ref ref="FLUENCY" />
+    </springProfile>
+    <springProfile name="!production">
+      <appender-ref ref="STDOUT"/>
+    </springProfile>
+  </root>
+
+</configuration>


### PR DESCRIPTION
# Resolves
Add fluentd logback appender
https://jira.rax.io/browse/SALUS-457
Add app config option for publishing actuator metrics to Influx
https://jira.rax.io/browse/SALUS-570

# What

Adds the config files for the subsystems above.
