### PR TITLE
Include the zone as a tag on metrics gathered by a remote monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/BoundMonitorUtils.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/BoundMonitorUtils.java
@@ -23,6 +23,7 @@ public class BoundMonitorUtils {
   public static final String LABEL_TARGET_TENANT = "target_tenant";
   public static final String LABEL_RESOURCE = "resource_id";
   public static final String LABEL_MONITOR_ID = "monitor_id";
+  public static final String LABEL_ZONE = "monitoring_zone";
 
   public static String buildConfiguredMonitorId(BoundMonitorDTO boundMonitor) {
     // don't need to qualify resource ID by resource tenant since monitor ID is already distinct

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
@@ -68,6 +68,7 @@ public class ConfigInstructionsBuilder {
     if (isRemoteMonitor(boundMonitor)) {
       opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_TARGET_TENANT, boundMonitor.getTenantId());
       opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_RESOURCE, boundMonitor.getResourceId());
+      opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_ZONE, boundMonitor.getZoneName());
     }
 
     return this;

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
@@ -128,7 +128,8 @@ public class ConfigInstructionsBuilderTest {
     assertThat(telegrafConfig.getOperations(3).getExtraLabelsMap(), allOf(
         hasEntry(BoundMonitorUtils.LABEL_TARGET_TENANT, "t-1"),
         hasEntry(BoundMonitorUtils.LABEL_RESOURCE, "r-2"),
-        hasEntry(BoundMonitorUtils.LABEL_MONITOR_ID, "00000000-0000-0005-0000-000000000000")
+        hasEntry(BoundMonitorUtils.LABEL_MONITOR_ID, "00000000-0000-0005-0000-000000000000"),
+        hasEntry(BoundMonitorUtils.LABEL_ZONE, "z-1")
         )
     );
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-591

# What

Including the zone is needed to differentiate and correlate metrics gathered by the same monitor but bound and observed from different zones.

# How

The config instructions builder already provides tags like tenant and resource ID for remote monitors which is needed to re-associate metrics with the tenant and resource via our public poller-envoys. I added another label/tag to that which is the monitoring zone and will get passed through by the `MetricRouter`.

# How to test

Updated the unit test