### PR TITLE
Allowing monitoring interval to be configurable per monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
@@ -25,10 +25,12 @@ import com.rackspace.salus.services.TelemetryEdge.EnvoyInstructionConfigure;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstructionConfigure.Builder;
 import com.rackspace.salus.telemetry.messaging.OperationType;
 import com.rackspace.salus.telemetry.model.AgentType;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
@@ -61,7 +63,8 @@ public class ConfigInstructionsBuilder {
     final ConfigurationOp.Builder opBuilder = builder.addOperationsBuilder()
         .setId(BoundMonitorUtils.buildConfiguredMonitorId(boundMonitor))
         .setType(convertOpType(operationType))
-        .setContent(boundMonitor.getRenderedContent());
+        .setContent(boundMonitor.getRenderedContent())
+        .setInterval(convertIntervalToSeconds(boundMonitor.getInterval()));
 
     opBuilder.putExtraLabels(BoundMonitorUtils.LABEL_MONITOR_ID, boundMonitor.getMonitorId().toString());
 
@@ -72,6 +75,10 @@ public class ConfigInstructionsBuilder {
     }
 
     return this;
+  }
+
+  static long convertIntervalToSeconds(@Nullable Duration interval) {
+    return interval != null ? interval.toSeconds() : 0;
   }
 
   private boolean isRemoteMonitor(BoundMonitorDTO boundMonitor) {

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EventProducer.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EventProducer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.ambassador.services;
+
+import static com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder.buildMessageKey;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.AttachEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+import org.springframework.util.concurrent.ListenableFuture;
+
+/**
+ * Consolidates Kafka event producing operations
+ */
+@Service
+public class EventProducer {
+
+  private final KafkaTemplate<String,Object> kafkaTemplate;
+  private final KafkaTopicProperties kafkaTopics;
+
+  @Autowired
+  public EventProducer(KafkaTemplate<String,Object> kafkaTemplate, KafkaTopicProperties kafkaTopics) {
+    this.kafkaTemplate = kafkaTemplate;
+    this.kafkaTopics = kafkaTopics;
+  }
+
+  ListenableFuture<SendResult<String, Object>> sendAttach(AttachEvent attachEvent) {
+    return kafkaTemplate.send(
+        kafkaTopics.getAttaches(),
+        buildMessageKey(attachEvent),
+        attachEvent
+    );
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-592

# What

Propagates the monitoring interval from the bound monitor DTO into the configuration instruction.

The twist here is that the `EnvoyRegistry` change tracking needed to be enhanced to account for just that field changing and/or the rendered content changing.

# How to test

Updated unit tests