### PR TITLE
Add Apache httpcomponents to ease SSL configurability of Vault client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,10 @@
             <version>2.0.25.Final</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.vault</groupId>
             <artifactId>spring-vault-core</artifactId>
             <version>2.1.0.RELEASE</version>


### PR DESCRIPTION
# What

SSL connectivity issues to Vault in the GCP dev cluster have revealed that the `VAULT_SSL_*` config isn't even getting used because our apps are using the builtin Java client as described here

https://docs.spring.io/spring-vault/docs/2.1.3.RELEASE/reference/html/#_javas_builtin_httpurlconnection

# How

Follow the solution describing in the section after the one above and add a dependency on Apache httpcomponents.

# How to test

Manually configured the application locally to use Vault but stop the Vault container to confirm the failed connectivity exception came from httpcomponents:

```
Caused by: org.springframework.vault.authentication.VaultLoginException: Cannot login using org.springframework.web.client.ResourceAccessException: I/O error on POST request for "http://localhost:8200/v1/auth/approle/login": Connect to localhost:8200 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (Connection refused); nested exception is org.apache.http.conn.HttpHostConnectException: Connect to localhost:8200 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (Connection refused)
```

/cc @nicksunday @dgvigil 