### PR TITLE
Add monitor type label to config instruction so telegraf emits it

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
@@ -42,6 +42,7 @@ public class ConfigInstructionsBuilder {
   public static final String LABEL_TARGET_TENANT = "target_tenant";
   public static final String LABEL_RESOURCE = "resource_id";
   public static final String LABEL_MONITOR_ID = "monitor_id";
+  public static final String LABEL_MONITOR_TYPE = "monitor_type";
   public static final String LABEL_ZONE = "monitoring_zone";
   private HashMap<AgentType, EnvoyInstructionConfigure.Builder> buildersByAgentType = new LinkedHashMap<>();
 
@@ -78,6 +79,7 @@ public class ConfigInstructionsBuilder {
         .setInterval(convertIntervalToSeconds(boundMonitor.getInterval()));
 
     opBuilder.putExtraLabels(LABEL_MONITOR_ID, boundMonitor.getMonitorId().toString());
+    opBuilder.putExtraLabels(LABEL_MONITOR_TYPE, boundMonitor.getMonitorType().toString());
 
     if (isRemoteMonitor(boundMonitor)) {
       opBuilder.putExtraLabels(LABEL_TARGET_TENANT, boundMonitor.getTenantId());

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilderTest.java
@@ -31,6 +31,7 @@ import com.rackspace.salus.services.TelemetryEdge.ConfigurationOp.Type;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstruction;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstructionConfigure;
 import com.rackspace.salus.telemetry.messaging.OperationType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -56,6 +57,7 @@ public class ConfigInstructionsBuilderTest {
             .setTenantId("t-1")
             .setRenderedContent("content1")
             .setMonitorId(m1)
+            .setMonitorType(MonitorType.cpu)
             .setResourceId("r-1")
             .setInterval(Duration.ofSeconds(30)),
         OperationType.CREATE
@@ -67,6 +69,8 @@ public class ConfigInstructionsBuilderTest {
             .setTenantId("t-1")
             .setRenderedContent("content2")
             .setMonitorId(m2)
+            // differ the monitor type just for some variance
+            .setMonitorType(MonitorType.mem)
             .setResourceId("r-1")
             .setInterval(Duration.ofSeconds(31)),
         OperationType.UPDATE
@@ -78,6 +82,7 @@ public class ConfigInstructionsBuilderTest {
             .setTenantId("t-1")
             .setRenderedContent("")
             .setMonitorId(m3)
+            .setMonitorType(MonitorType.cpu)
             .setResourceId("r-1")
             .setInterval(Duration.ofSeconds(32)),
         OperationType.DELETE
@@ -89,6 +94,7 @@ public class ConfigInstructionsBuilderTest {
             .setTenantId("t-1")
             .setRenderedContent("content4")
             .setMonitorId(m4)
+            .setMonitorType(MonitorType.log)
             .setResourceId("r-1")
             .setInterval(Duration.ofSeconds(33)),
         OperationType.CREATE
@@ -99,6 +105,7 @@ public class ConfigInstructionsBuilderTest {
             .setAgentType(TELEGRAF)
             .setRenderedContent("content5")
             .setMonitorId(m5)
+            .setMonitorType(MonitorType.cpu)
             .setTenantId("t-1")
             .setResourceId("r-2")
             .setZoneName("z-1")
@@ -119,7 +126,8 @@ public class ConfigInstructionsBuilderTest {
     assertThat(telegrafConfig.getOperations(0).getContent(), equalTo("content1"));
     assertThat(telegrafConfig.getOperations(0).getInterval(), equalTo(30L));
     assertThat(telegrafConfig.getOperations(0).getExtraLabelsMap(), allOf(
-        hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_ID, "00000000-0000-0001-0000-000000000000")
+        hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_ID, "00000000-0000-0001-0000-000000000000"),
+        hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_TYPE, "cpu")
         )
     );
 
@@ -129,7 +137,8 @@ public class ConfigInstructionsBuilderTest {
     assertThat(telegrafConfig.getOperations(1).getContent(), equalTo("content2"));
     assertThat(telegrafConfig.getOperations(1).getInterval(), equalTo(31L));
     assertThat(telegrafConfig.getOperations(1).getExtraLabelsMap(), allOf(
-        hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_ID, "00000000-0000-0002-0000-000000000000")
+        hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_ID, "00000000-0000-0002-0000-000000000000"),
+        hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_TYPE, "mem")
         )
     );
 
@@ -147,6 +156,7 @@ public class ConfigInstructionsBuilderTest {
         hasEntry(ConfigInstructionsBuilder.LABEL_TARGET_TENANT, "t-1"),
         hasEntry(ConfigInstructionsBuilder.LABEL_RESOURCE, "r-2"),
         hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_ID, "00000000-0000-0005-0000-000000000000"),
+        hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_TYPE, "cpu"),
         hasEntry(ConfigInstructionsBuilder.LABEL_ZONE, "z-1")
         )
     );
@@ -161,7 +171,8 @@ public class ConfigInstructionsBuilderTest {
     assertThat(filebeatConfig.getOperations(0).getContent(), equalTo("content4"));
     assertThat(filebeatConfig.getOperations(0).getInterval(), equalTo(33L));
     assertThat(filebeatConfig.getOperations(0).getExtraLabelsMap(), allOf(
-        hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_ID, "00000000-0000-0004-0000-000000000000")
+        hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_ID, "00000000-0000-0004-0000-000000000000"),
+        hasEntry(ConfigInstructionsBuilder.LABEL_MONITOR_TYPE, "log")
         )
     );
   }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-643

# What

Downstream processing, such as the event engine, can benefit by having a stable indication of the monitor type associated with a given metric frame. In those cases it can be used as a grouping for the individual metric name conveyed in those metric frames.

# How

Includes the monitor type as a label where labels get converted to extra tags in the telegraf plugin config. In turn telegraf includes the extra tags in the metrics payload that it sends out.

# How to test

Updated applicable unit tests

# Depends on

- https://github.com/racker/salus-telemetry-model/pull/81
- https://github.com/racker/salus-telemetry-monitor-management/pull/102