### PR TITLE
Fix MonitorBindingServiceTest due to monitor type field added

### DIFF
--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MonitorBindingServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MonitorBindingServiceTest.java
@@ -34,6 +34,7 @@ import com.rackspace.salus.services.TelemetryEdge.EnvoyInstruction;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstructionConfigure;
 import com.rackspace.salus.telemetry.messaging.OperationType;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -74,12 +75,14 @@ public class MonitorBindingServiceTest {
     List<BoundMonitorDTO> boundMonitors = Arrays.asList(
         new BoundMonitorDTO()
             .setMonitorId(id1)
+            .setMonitorType(MonitorType.cpu)
             .setResourceId("r-1")
             .setAgentType(AgentType.TELEGRAF)
             .setTenantId("t-1")
             .setRenderedContent("content1"),
         new BoundMonitorDTO()
             .setMonitorId(id2)
+            .setMonitorType(MonitorType.cpu)
             .setResourceId("r-2")
             .setAgentType(AgentType.FILEBEAT)
             .setTenantId("t-2")


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-643

# What

Google Cloud builds were being very laggy, so I merged https://github.com/racker/salus-telemetry-ambassador/pull/65 hoping the build on master would actually start (and run) correctly. It turns out there was a unit test I missed.

# How

Fixed a unit test that needed the new monitor type field set.

# How to test

Existing unit tests