### PR TITLE
Add optional support for sending metrics to elastic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
+            <artifactId>micrometer-registry-elastic</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,6 @@ management:
         uri: ${salus.metrics.influx.uri:http://localhost:8086}
         db: salus
         enabled: ${salus.metrics.influx.enabled:false}
+      elastic:
+        enabled: ${salus.metrics.elastic.enabled:false}
+        host: ${salus.metrics.elastic.uri:http://localhost:9200}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-688

# What

For our internal monitoring it would be nice to consolidate down to the minimal set of services/tools to maintain. The original thought was to use

- InfluxDB + Grafana : for metrics
- Elasticsearch + Kibana : for logs

however, when Elastic starting getting into the metrics game with metricbeat, they added a feature called [Timelion](https://www.elastic.co/guide/en/kibana/current/timelion.html) to Kibana for first-class metrics query and charting.

# How

Adds the micrometer dependency on elastic, but like we do for influxdb, introduce an application property that disables it by default.

# TODO

If we like the usability of timelion, then the elastic dependency can be added to salus-app-base and the default `application.yml` changes to the other apps.

# Kubernetes / Environment Variable config

```yaml
  SALUS_METRICS_ELASTIC_ENABLED: "true"
  SALUS_METRICS_ELASTIC_URI: http://es-ingest.salus-development.svc.cluster.local:9200
```

cc @nicksunday 