### PR TITLE
Upgraded salus-telemetry-protocol to pick up packages agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 Rackspace US, Inc.
+  ~ Copyright 2020 Rackspace US, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-protocol</artifactId>
-            <version>0.2-SNAPSHOT</version>
+            <version>0.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.monplat</groupId>


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-594

# What

Since Envoy uses Go modules, the protocol module actually gets a [proper Maven release and **tag**](https://github.com/racker/salus-telemetry-protocol#performing-a-release), which is what we'll eventually be doing with all of our other modules. This Ambassador upgrade wasn't technically needed since I forgot to bump the version to `0.3-SNAPSHOT` in https://github.com/racker/salus-telemetry-protocol/pull/18 prior to doing the https://github.com/racker/salus-telemetry-protocol/releases/tag/v0.3.0 release.

But...this PR makes everything right by lining up the snapshot versions for our development workspace.