### PR TITLE
Fixed config instruction building when a monitor is deleted

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ConfigInstructionsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,13 +78,15 @@ public class ConfigInstructionsBuilder {
         .setContent(boundMonitor.getRenderedContent())
         .setInterval(convertIntervalToSeconds(boundMonitor.getInterval()));
 
-    opBuilder.putExtraLabels(LABEL_MONITOR_ID, boundMonitor.getMonitorId().toString());
-    opBuilder.putExtraLabels(LABEL_MONITOR_TYPE, boundMonitor.getMonitorType().toString());
+    if (!operationType.equals(OperationType.DELETE)) {
+      opBuilder.putExtraLabels(LABEL_MONITOR_ID, boundMonitor.getMonitorId().toString());
+      opBuilder.putExtraLabels(LABEL_MONITOR_TYPE, boundMonitor.getMonitorType().toString());
 
-    if (isRemoteMonitor(boundMonitor)) {
-      opBuilder.putExtraLabels(LABEL_TARGET_TENANT, boundMonitor.getTenantId());
-      opBuilder.putExtraLabels(LABEL_RESOURCE, boundMonitor.getResourceId());
-      opBuilder.putExtraLabels(LABEL_ZONE, boundMonitor.getZoneName());
+      if (isRemoteMonitor(boundMonitor)) {
+        opBuilder.putExtraLabels(LABEL_TARGET_TENANT, boundMonitor.getTenantId());
+        opBuilder.putExtraLabels(LABEL_RESOURCE, boundMonitor.getResourceId());
+        opBuilder.putExtraLabels(LABEL_ZONE, boundMonitor.getZoneName());
+      }
     }
 
     return this;


### PR DESCRIPTION
# What

When integration testing the packages agent I observed the following exception in the ambassador when deleting a monitor:

```
2020-01-21 15:34:18.861 DEBUG 30814 --- [ntainer#2-0-C-1] c.r.s.t.a.services.MonitorEventListener  : Handling monitorBoundEvent=MonitorBoundEvent(envoyId=3cf5d0d0-3c95-11ea-8d2e-c4b301c45f69)
2020-01-21 15:34:18.861 DEBUG 30814 --- [ntainer#2-0-C-1] c.r.s.t.a.s.MonitorBindingService        : Getting bound monitors for envoy=3cf5d0d0-3c95-11ea-8d2e-c4b301c45f69 with agentInstalls={TELEGRAF=1.11.5, PACKAGES=0.1.0}
2020-01-21 15:34:18.913 DEBUG 30814 --- [ntainer#2-0-C-1] c.r.s.t.a.s.MonitorBindingService        : Applied boundMonitors=[] and computed changes={DELETE=[BoundMonitorDTO(monitorId=1a7a769b-f1e2-4d5d-a61e-0e0d427e0e69, monitorType=null, tenantId=aaaaaa, zoneName=null, resourceId=development:0, interval=null, selectorScope=null, agentType=PACKAGES, renderedContent=, envoyId=null, createdTimestamp=null, updatedTimestamp=null)]}
2020-01-21 15:34:18.924  WARN 30814 --- [ntainer#2-0-C-1] c.r.s.common.messaging.KafkaErrorConfig  : Handling listener container error by skipping offset=8 in=telemetry.monitors.json-0

org.springframework.kafka.listener.ListenerExecutionFailedException: Listener method 'public void com.rackspace.salus.telemetry.ambassador.services.MonitorEventListener.handleMessage(com.rackspace.salus.telemetry.messaging.MonitorBoundEvent)' threw exception; nested exception is java.lang.NullPointerException; nested exception is java.lang.NullPointerException
Caused by: java.lang.NullPointerException: null
	at com.rackspace.salus.telemetry.ambassador.services.ConfigInstructionsBuilder.add(ConfigInstructionsBuilder.java:82)
	at com.rackspace.salus.telemetry.ambassador.services.MonitorBindingService.processEnvoy(MonitorBindingService.java:75)
	at com.rackspace.salus.telemetry.ambassador.services.MonitorBindingService.processEnvoy(MonitorBindingService.java:46)
	at com.rackspace.salus.telemetry.ambassador.services.MonitorEventListener.handleMessage(MonitorEventListener.java:79)
```

# How

It turns out this must have been broken since https://github.com/racker/salus-telemetry-ambassador/pull/65

Setting the extra labels doesn't even make sense for a deletion operation, so I wrapped that bit in a conditional.

# How to test

Added a unit test that replicated the exact interaction that happens between `EnvoyRegistry.applyBoundMonitors` and `ConfigInstructionsBuilder.build` where the subtle but important part was that `monitorType` of the synthetic `BoundMonitorDTO` is null.