### PR TITLE
Added resourceId and measurementName to kafka metrics routing key

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/KafkaEgress.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.services;
@@ -37,7 +35,7 @@ public class KafkaEgress {
         this.kafkaTopics = kafkaTopics;
     }
 
-    public void send(String tenantId, KafkaMessageType messageType, String payload) {
+    public void send(String routingKey, KafkaMessageType messageType, String payload) {
         final String topic;
         switch (messageType) {
             case METRIC:
@@ -51,6 +49,6 @@ public class KafkaEgress {
                     String.format("Unsupported messageType=%s for kafka routing", messageType));
         }
 
-        kafkaTemplate.send(topic, tenantId, payload);
+        kafkaTemplate.send(topic, routingKey, payload);
     }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/LogEventRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/LogEventRouter.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.services;
@@ -26,8 +24,10 @@ import com.rackspace.salus.services.TelemetryEdge.LogEvent;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -89,7 +89,8 @@ public class LogEventRouter {
                 final String enrichedJson = objectMapper.writeValueAsString(eventObj);
 
                 log.trace("Sending: {}", enrichedJson);
-                kafkaEgress.send(tenantId, KafkaMessageType.LOG, enrichedJson);
+                kafkaEgress.send(Strings.join(List.of(tenantId, resourceId), ','),
+                    KafkaMessageType.LOG, enrichedJson);
             }
             else {
                 log.warn("Unexpected json tree type: {}", event);

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,12 +31,14 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -86,13 +88,14 @@ public class MetricRouter {
         // resource of the monitor.
 
         String resourceId = tagsMap.remove(ConfigInstructionsBuilder.LABEL_RESOURCE);
+        final String measurementName = nameTagValue.getName();
         if (resourceId == null) {
             resourceId = envoyRegistry.getResourceId(envoyId);
 
             if (resourceId == null) {
                 log.warn("Unable to locate resourceId while routing"
                         + " measurement={} for tenant={} envoy={} tags={}",
-                    nameTagValue.getName(), tenantId, envoyId, nameTagValue.getTagsMap());
+                    measurementName, tenantId, envoyId, nameTagValue.getTagsMap());
                 return;
             }
         }
@@ -121,7 +124,7 @@ public class MetricRouter {
             .setMonitoringSystem(MonitoringSystem.SALUS)
             .setSystemMetadata(Collections.singletonMap("envoyId", envoyId))
             .setCollectionMetadata(tagsMap)
-            .setCollectionName(nameTagValue.getName())
+            .setCollectionName(measurementName)
             .setFvalues(nameTagValue.getFvaluesMap())
             .setSvalues(nameTagValue.getSvaluesMap())
             .setIvalues(Collections.emptyMap())
@@ -138,7 +141,8 @@ public class MetricRouter {
             jsonEncoder.flush();
 
             metricsRouted.increment();
-            kafkaEgress.send(tenantId, KafkaMessageType.METRIC, out.toString(StandardCharsets.UTF_8.name()));
+            kafkaEgress.send(Strings.join(List.of(tenantId, resourceId, measurementName), ','),
+                KafkaMessageType.METRIC, out.toString(StandardCharsets.UTF_8.name()));
 
         } catch (IOException|NullPointerException e) {
             log.warn("Failed to Avro encode avroMetric={} original={}", externalMetric, postedMetric, e);

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/KafkaEgressTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/KafkaEgressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ public class KafkaEgressTest {
 
   @Test
   public void testMetricsEncodedAsSent() {
-    kafkaEgress.send("tenant-1", KafkaMessageType.METRIC, "{\"id\":1}");
+    kafkaEgress.send("tenant-1,r-1,m-1", KafkaMessageType.METRIC, "{\"id\":1}");
 
     final Consumer<String, String> consumer = buildConsumer(
         StringDeserializer.class,
@@ -108,7 +108,7 @@ public class KafkaEgressTest {
 
     // Use Hamcrest matchers provided by spring-kafka-test
     // https://docs.spring.io/spring-kafka/docs/2.2.4.RELEASE/reference/#hamcrest-matchers
-    assertThat(record, hasKey("tenant-1"));
+    assertThat(record, hasKey("tenant-1,r-1,m-1"));
     assertThat(record, hasValue("{\"id\":1}"));
   }
 

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouterTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ public class MetricRouterTest {
 
         verify(resourceLabelsService).getResourceLabels("t1", "r-1");
         verify(envoyRegistry).getResourceId("envoy-1");
-        verify(kafkaEgress).send("t1", KafkaMessageType.METRIC,
+        verify(kafkaEgress).send("t1,r-1,cpu", KafkaMessageType.METRIC,
             readContent("/MetricRouterTest/testRouteMetric.json"));
 
         verifyNoMoreInteractions(kafkaEgress, envoyRegistry);
@@ -133,7 +133,7 @@ public class MetricRouterTest {
         metricRouter.route("t1", "envoy-1", postedMetric);
 
         verify(resourceLabelsService).getResourceLabels("t-some-other", "r-other");
-        verify(kafkaEgress).send("t-some-other", KafkaMessageType.METRIC,
+        verify(kafkaEgress).send("t-some-other,r-other,cpu", KafkaMessageType.METRIC,
             readContent("/MetricRouterTest/testRouteMetric_withTargetTenant.json"));
 
         verifyNoMoreInteractions(kafkaEgress, envoyRegistry);


### PR DESCRIPTION
# Resolves

Helps https://jira.rax.io/browse/SALUS-751

# What

Metrics routed from ambassador into kafka were only getting sent to a single partition during performance testing. This was due to only the tenantId being used for the routing key. In production that would be problematic too since large customers could cause a partition-hot-spot.

# How

Renamed and repurposed the `KafkaEgress.send` parameter to be a routing key and allow the metrics and log router to do specific string joins to also include the resource ID and measurement name (in the case of metrics).

# How to test

Updated unit tests