### PR TITLE
Add common dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
             </exclusions>
         </dependency>
         <dependency>
+        <groupId>com.rackspace.salus</groupId>
+        <artifactId>salus-common</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-protocol</artifactId>
             <version>0.3-SNAPSHOT</version>

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EventProducer.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EventProducer.java
@@ -16,7 +16,7 @@
 
 package com.rackspace.salus.telemetry.ambassador.services;
 
-import static com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder.buildMessageKey;
+import static com.rackspace.salus.telemetry.messaging.KafkaMessageKeyBuilder.buildMessageKey;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.AttachEvent;


### PR DESCRIPTION
Required due to https://github.com/racker/salus-telemetry-model/pull/113

Model no longer depends on common so it has to be pulled in separately. 