### PR TITLE
Adam9500/validate resource

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -57,6 +57,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -155,8 +156,13 @@ public class EnvoyRegistry {
         envoySummary.getSupportedAgentsList());
 
     final String resourceId = envoySummary.getResourceId();
+    final Pattern resourceValidation = Pattern.compile("[A-Za-z0-9:-]+");
+    // we can check here... But lets follow this through to make sure we get the actual problem
     if (!StringUtils.hasText(resourceId)) {
       throw new StatusException(Status.INVALID_ARGUMENT.withDescription("resourceId is required"));
+    } else if (!resourceValidation.matcher(resourceId).matches()) {
+      // invalid resourceId
+      throw new StatusException(Status.INVALID_ARGUMENT.withDescription("resourceId may only contain alphanumeric's, ':', or '-'"));
     }
 
     EnvoyEntry existingEntry = envoys.get(envoyId);

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -157,11 +157,9 @@ public class EnvoyRegistry {
 
     final String resourceId = envoySummary.getResourceId();
     final Pattern resourceValidation = Pattern.compile("[A-Za-z0-9:-]+");
-    // we can check here... But lets follow this through to make sure we get the actual problem
     if (!StringUtils.hasText(resourceId)) {
       throw new StatusException(Status.INVALID_ARGUMENT.withDescription("resourceId is required"));
     } else if (!resourceValidation.matcher(resourceId).matches()) {
-      // invalid resourceId
       throw new StatusException(Status.INVALID_ARGUMENT.withDescription("resourceId may only contain alphanumeric's, ':', or '-'"));
     }
 

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -148,6 +148,19 @@ public class EnvoyRegistryTest {
         );
   }
 
+  @Test(expected = StatusException.class)
+  public void postsAttachEventOnAttachFailsWithBadResourceId() throws StatusException {
+    final EnvoySummary envoySummary = EnvoySummary.newBuilder()
+        .setResourceId("$hostname:test-host")
+        .putLabels("discovered_os", "linux")
+        .build();
+
+    // We expect this to throw the StatusException
+    envoyRegistry.attach("t-1", "e-1", envoySummary,
+        InetSocketAddress.createUnresolved("localhost", 60000), streamObserver
+    ).join();
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void storesZoneOnAttach() throws StatusException, ZoneNotAuthorizedException {

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.telemetry.ambassador.services;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -60,6 +61,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -149,19 +151,18 @@ public class EnvoyRegistryTest {
   }
 
   @Test
-  public void postsAttachEventOnAttachFailsWithBadResourceId() {
+  public void postsAttachEventOnAttachFailsWithBadResourceId() throws StatusException {
     final EnvoySummary envoySummary = EnvoySummary.newBuilder()
         .setResourceId("$hostname:test-host")
         .putLabels("discovered_os", "linux")
         .build();
 
-    try {
-      envoyRegistry.attach("t-1", "e-1", envoySummary,
-          InetSocketAddress.createUnresolved("localhost", 60000), streamObserver
-      ).join();
-    }catch(StatusException e) {
-      assertThat(e.getStatus().getDescription(), equalTo("resourceId may only contain alphanumeric's, ':', or '-'"));
-   }
+    assertThatThrownBy(() -> envoyRegistry.attach("t-1", "e-1", envoySummary,
+      InetSocketAddress.createUnresolved("localhost", 60000), streamObserver
+    ).join())
+        .isInstanceOf(StatusException.class)
+        .hasMessageContaining("resourceId may only contain alphanumeric's, ':', or '-'");
+
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -148,17 +148,20 @@ public class EnvoyRegistryTest {
         );
   }
 
-  @Test(expected = StatusException.class)
-  public void postsAttachEventOnAttachFailsWithBadResourceId() throws StatusException {
+  @Test
+  public void postsAttachEventOnAttachFailsWithBadResourceId() {
     final EnvoySummary envoySummary = EnvoySummary.newBuilder()
         .setResourceId("$hostname:test-host")
         .putLabels("discovered_os", "linux")
         .build();
 
-    // We expect this to throw the StatusException
-    envoyRegistry.attach("t-1", "e-1", envoySummary,
-        InetSocketAddress.createUnresolved("localhost", 60000), streamObserver
-    ).join();
+    try {
+      envoyRegistry.attach("t-1", "e-1", envoySummary,
+          InetSocketAddress.createUnresolved("localhost", 60000), streamObserver
+      ).join();
+    }catch(StatusException e) {
+      assertThat(e.getStatus().getDescription(), equalTo("resourceId may only contain alphanumeric's, ':', or '-'"));
+   }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-778

# What

Validate that we have a properly formatted resourceId

# How

When we extract the resourceId out of the config that is sent to the ambassador we run a regex against it validating that the resourceId is a alphanumeric, ":", or "-"

# How to test

Run the unit tests

# Why

The Ambassador sends a Kafka event to resource-management and so a validation on the entity won't allow us to tell the Envoy that something went wrong.

# TODO

It should be done