### PR TITLE
Unified on 'errors' metric name

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
@@ -74,7 +74,7 @@ public class EnvoyAmbassadorService extends TelemetryAmbassadorImplBase {
         postLog = meterRegistry.counter("messages","operation", "postLog");
         messagesPost = meterRegistry.counter("messages","operation", "postMetric");
         keepAlive = meterRegistry.counter("messages","operation", "keepAlive");
-        exceptions = meterRegistry.counter("errors", "type", "exception");
+        exceptions = meterRegistry.counter("errors", "cause", "unhandledException");
     }
 
     @Override

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class EnvoyAmbassadorService extends TelemetryAmbassadorImplBase {
         postLog = meterRegistry.counter("messages","operation", "postLog");
         messagesPost = meterRegistry.counter("messages","operation", "postMetric");
         keepAlive = meterRegistry.counter("messages","operation", "keepAlive");
-        exceptions = meterRegistry.counter("exceptions", "errors", "exceptions");
+        exceptions = meterRegistry.counter("errors", "type", "exception");
     }
 
     @Override

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/MetricRouter.java
@@ -68,7 +68,7 @@ public class MetricRouter {
         universalTimestampFormatter = DateTimeFormatter.ISO_INSTANT;
 
         metricsRouted = meterRegistry.counter("routed", "type", "metrics");
-        missingResourceLabelTracking = meterRegistry.counter("error", "cause", "missingResourceLabelTracking");
+        missingResourceLabelTracking = meterRegistry.counter("errors", "cause", "missingResourceLabelTracking");
     }
 
     public void route(String tenantId, String envoyId,

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ResourceLabelsService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/ResourceLabelsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,8 +70,8 @@ public class ResourceLabelsService implements ConsumerSeekAware {
     this.retryTemplate = retryTemplate;
     this.taskExecutor = taskExecutor;
 
-    releasingUntracked = meterRegistry.counter("error", "cause", "releasingUntrackedResource");
-    failedLabelsPull = meterRegistry.counter("error", "cause", "failedResourceLabelPull");
+    releasingUntracked = meterRegistry.counter("errors", "cause", "releasingUntrackedResource");
+    failedLabelsPull = meterRegistry.counter("errors", "cause", "failedResourceLabelPull");
   }
 
   @SuppressWarnings({"unused", "WeakerAccess"}) // used by SpEL


### PR DESCRIPTION
# What

When looking in grafana I noticed we had metrics named "errors" and "error". The plural makes more sense choosing between the two and ambassador happened to be the only place where I did the "error" naming thing.