### PR TITLE
Adam9500/salus 694 resource id lowercase

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -157,7 +157,7 @@ public class EnvoyRegistry {
     final List<String> supportedAgentTypes = convertToStrings(
         envoySummary.getSupportedAgentsList());
 
-    final String resourceId = envoySummary.getResourceId();
+    final String resourceId = envoySummary.getResourceId().toLowerCase();
 
     if (!StringUtils.hasText(resourceId)) {
       throw new StatusException(Status.INVALID_ARGUMENT.withDescription("resourceId is required"));

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -157,7 +157,7 @@ public class EnvoyRegistry {
     final List<String> supportedAgentTypes = convertToStrings(
         envoySummary.getSupportedAgentsList());
 
-    final String resourceId = envoySummary.getResourceId().toLowerCase();
+    final String resourceId = envoySummary.getResourceId();
 
     if (!StringUtils.hasText(resourceId)) {
       throw new StatusException(Status.INVALID_ARGUMENT.withDescription("resourceId is required"));
@@ -241,7 +241,7 @@ public class EnvoyRegistry {
       Map<String, String> envoyLabels,
       SocketAddress remoteAddr) {
 
-    final String resourceId = envoySummary.getResourceId();
+    final String resourceId = envoySummary.getResourceId().toLowerCase();
     final AttachEvent attachEvent = new AttachEvent()
         .setTenantId(tenantId)
         .setEnvoyId(envoyId)

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -114,7 +114,7 @@ public class EnvoyRegistryTest {
   @Test
   public void postsAttachEventOnAttach() throws StatusException {
     final EnvoySummary envoySummary = EnvoySummary.newBuilder()
-        .setResourceId("hostname:test-host")
+        .setResourceId("HOSTNAME:test-host")
         .putLabels("discovered_os", "linux")
         .build();
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-694

# What

Make sure that the resourceId is lowerCase when it gets stored in the database

# How

When we send the attach event through Kafka we make sure that the resourceId is lowercase. 

# How to test

Unit tests have been updated to test the new functionality of upper case letters getting turned into lower case letters.

# Why

If we grab the values as they enter our system we can easily make sure that the data is the way we expect it to be without having to do lots of extra validation throughout the codebase. 
