### PR TITLE
Allowed for fine tuning gRPC Netty boss/worker thread groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-protocol</artifactId>
-            <version>0.3-SNAPSHOT</version>
+            <version>0.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.monplat</groupId>
@@ -144,7 +144,7 @@
             <!-- for grpc tls support -->
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>2.0.25.Final</version>
+            <version>2.0.30.Final</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AmbassadorProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AmbassadorProperties.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.config;
@@ -55,4 +53,14 @@ public class AmbassadorProperties {
      * When calling APIs of other microservices, this will be the max attempts retried
      */
     int maxApiRetryAttempts = 10;
+
+    /**
+     * Specifies the number of threads used to accept incoming gRPC connections.
+     */
+    int grpcBossThreads = 2;
+    /**
+     * Specifies the number of threads used to process gRPC messages. Can be set to zero to
+     * use the default Netty calculation based on 2 * available processors.
+     */
+    int grpcWorkerThreads = 8;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.google.protobuf.util.JsonFormat;
 import io.grpc.ServerBuilder;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -57,7 +58,10 @@ public class GrpcConfig extends GRpcServerBuilderConfigurer {
 
     @Override
     public void configure(ServerBuilder<?> serverBuilder) {
-        final NettyServerBuilder nettyServerBuilder = (NettyServerBuilder) serverBuilder;
+        final NettyServerBuilder nettyServerBuilder =
+            ((NettyServerBuilder) serverBuilder)
+                .bossEventLoopGroup(new NioEventLoopGroup(appProperties.getGrpcBossThreads()))
+                .workerEventLoopGroup(new NioEventLoopGroup(appProperties.getGrpcWorkerThreads()));
 
         try {
             if (!appProperties.isDisableTls()) {


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-873

# What

While locating the fix in https://github.com/racker/salus-telemetry-etcd-adapter/pull/55 I realized that the boss and worker group given to Netty for serving gRPC were using the default thread count calculation of 2 x available processors. Since there are the two groups/pools, the overall allocation was 4 x available processors.

# How

Expose properties to fine tune the boss and worker groups independently. Even though they can be and should be reconfigured in production, the default sizes lean towards throttling new connection acceptance (2 threads) relative to active connection processing (with 8 threads).

The defaults also help guide us away from leaning on the "2 x available processor" algorithm, since it gets a little dicey in containerized deployments. Java 11 is better at deriving processor availability from the container/cgroup, but still allowing for explicit bounds feels more prudent.

# How to test

Using Envoy with

```
stress-connections --config=envoy-config-provided.yml --debug --connection-count=600 --connections-delay=100ms --metrics-per-minute=1
```

# Related to

https://github.com/racker/salus-telemetry-etcd-adapter/pull/55