### PR TITLE
Added "ready" instruction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,14 +73,14 @@
             </exclusions>
         </dependency>
         <dependency>
-        <groupId>com.rackspace.salus</groupId>
-        <artifactId>salus-common</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+            <groupId>com.rackspace.salus</groupId>
+            <artifactId>salus-common</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-protocol</artifactId>
-            <version>0.5-SNAPSHOT</version>
+            <version>0.6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.monplat</groupId>

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyAmbassadorService.java
@@ -85,7 +85,10 @@ public class EnvoyAmbassadorService extends TelemetryAmbassadorImplBase {
         registerCancelHandler(envoyId, remoteAddr, responseObserver);
         envoyAttach.increment();
         try {
-            envoyRegistry.attach(GrpcContextDetails.getCallerTenantId(), envoyId, request, remoteAddr, responseObserver).join();
+            envoyRegistry.attach(
+                GrpcContextDetails.getCallerTenantId(), envoyId, request, remoteAddr, responseObserver
+            )
+                .join();
         } catch (StatusException e) {
             responseObserver.onError(e);
         } catch (Exception e) {

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.when;
 
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.services.TelemetryEdge.EnvoyInstruction;
+import com.rackspace.salus.services.TelemetryEdge.EnvoyInstructionReady;
 import com.rackspace.salus.services.TelemetryEdge.EnvoySummary;
 import com.rackspace.salus.telemetry.ambassador.config.AmbassadorProperties;
 import com.rackspace.salus.telemetry.ambassador.config.GrpcConfig;
@@ -146,6 +147,11 @@ public class EnvoyRegistryTest {
                 .setTenantId("t-1")
                 .setEnvoyAddress("localhost")
         );
+
+    final EnvoyInstruction readyInstruction = EnvoyInstruction.newBuilder()
+        .setReady(EnvoyInstructionReady.newBuilder().build())
+        .build();
+    verify(streamObserver).onNext(readyInstruction);
   }
 
   @Test


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-852

# What

While preparing for measurements in the performance cluster I noticed that the Envoy was concurrently proceeding with keepalives even though the Envoy hadn't been fully registered by the Ambassador. From the Ambassador logs it looked like a race condition where the Envoy would initiate the attach, Ambassador would report debug logs about the initial attach, yet the log warning message "Did not have lease for envoyInstanceId" would appear during keepalive processing.

After further investigation I discovered the AttachEnvoy call over gRPC is asynchronous:

https://github.com/racker/salus-telemetry-envoy/blob/6a89a521b63c7cd424bc3f4a1a062f904b566619/ambassador/connection.go#L247

As a result, the Envoy would proceed to start the keepalive processing and acceptance of metrics for posting even though the Ambassador had not completed the processing of the AttachEnvoy call.

# How

Added a "ready" instruction that is sent by the Ambassador when the Envoy has been allocated a lease in etcd and registered in all of the appropriate lookup tables. There is still some asynchronous processing that happens after the ready instruction, such as label lookups, but those operations don't influence the ongoing connectivity of Envoy->Ambassador.

# How to test

Updated existing unit test to verify ready instruction is sent during attach.

# Depends on

https://github.com/racker/salus-telemetry-protocol/pull/20