### PR TITLE
Switched async to fixed thread pool and fixed related issues from 2000 envoy perf run

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AsyncConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AsyncConfig.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.config;
@@ -21,14 +19,18 @@ package com.rackspace.salus.telemetry.ambassador.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
+@EnableAsync
 public class AsyncConfig {
 
     @Bean
     public TaskExecutor taskExecutor() {
         final ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(4);
+        taskExecutor.setMaxPoolSize(4);
         taskExecutor.setThreadNamePrefix("async-");
         return taskExecutor;
     }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfig.java
@@ -25,6 +25,7 @@ import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.File;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -61,7 +62,10 @@ public class GrpcConfig extends GRpcServerBuilderConfigurer {
         final NettyServerBuilder nettyServerBuilder =
             ((NettyServerBuilder) serverBuilder)
                 .bossEventLoopGroup(new NioEventLoopGroup(appProperties.getGrpcBossThreads()))
-                .workerEventLoopGroup(new NioEventLoopGroup(appProperties.getGrpcWorkerThreads()));
+                .workerEventLoopGroup(new NioEventLoopGroup(
+                    appProperties.getGrpcWorkerThreads(),
+                    new DefaultThreadFactory("grpc-worker")
+                ));
 
         try {
             if (!appProperties.isDisableTls()) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,7 +5,6 @@ server:
 logging:
   level:
     com.rackspace.salus: debug
-    com.rackspace.salus.telemetry.ambassador.services.MonitorEventListener: trace
 salus:
   ambassador:
     public-zone-tenants:


### PR DESCRIPTION
# What/how

Building on discoveries in https://github.com/racker/salus-telemetry-etcd-adapter/pull/59 with etcd thread executor, configured the general purpose async executor used by ambassador to be a fixed thread pool.

Gave the gRPC/Netty worker threads a more helpful thread name.

Since I have since discovered the gRPC attach itself is asynchronous and rediscovered that the GrpcContext in our etcd gRPC usage can interfere with our envoy serving gRPC, I made the primary methods of EnvoyRegistry `@Async`. It also made tracing behavior more clear in the logs because I could pick off the "async-" prefixed thread names.

Speaking of which, sprinkled more debug logs in a few places that helped with the 2000 Envoy perf test fix/test cycle.

Removed the retry and async logic from resource label retrieval since it was overcomplicating my analysis of threading behavior during all the perf fixes. I did however relax the behavior when a new Envoy is first attaching and it is expected that resource label retrieval will get a 404 since resource manager won't have processed the attach event by that point.

# How to test

Adjusted unit tests but also confirmed at least 2000 Envoys were able to establish stable, error-free attachments to one Ambassador in perf cluster.