### PR TITLE
Upgraded grpc-spring-boot-starter to 3.5.3 to pickup grpc 1.28.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-protocol</artifactId>
-            <version>0.6-SNAPSHOT</version>
+            <version>0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.monplat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -131,20 +131,14 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.9.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.lognet</groupId>
+            <groupId>io.github.lognet</groupId>
             <artifactId>grpc-spring-boot-starter</artifactId>
-            <version>2.4.2</version>
+            <version>3.5.3</version>
         </dependency>
         <dependency>
             <!-- for grpc tls support -->
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>2.0.30.Final</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfig.java
@@ -21,6 +21,7 @@ import io.grpc.ServerBuilder;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -65,7 +66,8 @@ public class GrpcConfig extends GRpcServerBuilderConfigurer {
                 .workerEventLoopGroup(new NioEventLoopGroup(
                     appProperties.getGrpcWorkerThreads(),
                     new DefaultThreadFactory("grpc-worker")
-                ));
+                ))
+                .channelType(NioServerSocketChannel.class);
 
         try {
             if (!appProperties.isDisableTls()) {

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -64,7 +64,6 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.support.SendResult;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -139,7 +138,6 @@ public class EnvoyRegistry {
    * @param instructionStreamObserver the response stream
    * @return a {@link CompletableFuture} of the lease ID granted to the attached Envoy
    */
-  @Async
   public CompletableFuture<?> attach(String tenantId, String envoyId, EnvoySummary envoySummary,
       SocketAddress remoteAddr, StreamObserver<EnvoyInstruction> instructionStreamObserver)
       throws StatusException {
@@ -325,7 +323,6 @@ public class EnvoyRegistry {
    * </p>
    * @param instanceId
    */
-  @Async
   public void remove(String instanceId) {
     log.debug("Removing registration of envoyInstance={}", instanceId);
     final EnvoyEntry entry = envoys.remove(instanceId);


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-852

# What

There was [an issue](https://github.com/racker/salus-telemetry-ambassador/pull/87#issuecomment-618515022) where grpc server callbacks in ambassador were interfering with grpc client calls to etcd.

# How

Upgraded grpc-spring-boot-starter which aligned with grpc 1.28.1. As a result, the original issue with grpc server callback interfering with grpc client call went away and the extra `@Async` "layer" wasn't needed in the `EnvoyRegistry` interactions.

Latest grpc library insisted on `channelType` being set along with the event loop groups.

# How to test

Existing units but also manually with envoy's stress-connections mode.

# Depends on

- https://github.com/racker/salus-telemetry-protocol/pull/21
- https://github.com/racker/salus-telemetry-etcd-adapter/pull/60