### PR TITLE
fix for older versions of osx

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
             <!-- for grpc tls support -->
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>2.0.29.Final</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
getting this error on ambassador envoy connections:
dyld: lazy symbol binding failed: Symbol not found: ____chkstk_darwin
  Referenced from: /private/var/folders/tv/62l3ly3n2851dz2hd9v4jbbxbcr_cf/T/libnetty_tcnative_osx_x86_648637683648409394884.dylib (which was built for Mac OS X 10.15)
  Expected in: /usr/lib/libSystem.B.dylib


fix recommended here:
https://github.com/netty/netty-tcnative/issues/523

