### PR TITLE
Upgraded to grpc 1.30.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,15 +143,20 @@
         </dependency>
 
         <dependency>
+            <!-- https://mvnrepository.com/artifact/io.github.lognet/grpc-spring-boot-starter/3.5.6 -->
             <groupId>io.github.lognet</groupId>
             <artifactId>grpc-spring-boot-starter</artifactId>
-            <version>3.5.3</version>
+            <version>3.5.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
         </dependency>
         <dependency>
             <!-- for grpc tls support -->
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>2.0.29.Final</version>
+            <version>2.0.31.Final</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-protocol</artifactId>
-            <version>0.7-SNAPSHOT</version>
+            <version>0.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.monplat</groupId>


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-982

# What

With https://github.com/racker/salus-app-base/pull/30 we starting getting maven/compile conflicts regarding protobuf's `JsonFormat`, so it was a good time to go ahead and upgrade grpc to line things up.

# How

Bumped the version for Maven and Go builds. As a reminder, generated Go code needs to be source controlled since Go builds pull dependencies via github.

# How to test

With protocol, ambassador, and envoy changes all in place, ensured Envoy to Ambassador connectivity is still working normally.

# Depends on

- https://github.com/racker/salus-telemetry-protocol/pull/22