### PR TITLE
Colocated envoy lease duration config

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AmbassadorProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/AmbassadorProperties.java
@@ -16,14 +16,13 @@
 
 package com.rackspace.salus.telemetry.ambassador.config;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
-import org.hibernate.validator.constraints.Mod10Check;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -35,7 +34,9 @@ import org.springframework.validation.annotation.Validated;
 public class AmbassadorProperties {
 
     @NotBlank
-    String envoyRefreshInterval = "PT10S";
+    String envoyRefreshInterval = "PT45S";
+
+    Duration envoyLeaseDuration = Duration.ofSeconds(60);
 
     @Min(1)
     long envoyRefreshParallelism = 5;
@@ -57,9 +58,6 @@ public class AmbassadorProperties {
     String externalName = "localhost";
     @NotEmpty
     List<String> altExternalNames = Collections.singletonList("127.0.0.1");
-
-    @Min(1)
-    long envoyLeaseSec = 30;
 
     /**
      * Only Envoys of these tenants are allowed to advertise a zone with prefixed with 'publicZonePrefix'
@@ -86,7 +84,7 @@ public class AmbassadorProperties {
     int grpcWorkerThreads = 8;
 
     /**
-     * Specifies number of threads used to process server methods and etcd client calls.
+     * Specifies number of threads used to process gRPC server methods and detachment.
      */
     @Min(1)
     int asyncThreads = 8;

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfig.java
@@ -41,7 +41,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.util.Assert;
 import org.springframework.vault.core.VaultTemplate;
@@ -50,7 +49,6 @@ import org.springframework.vault.support.VaultCertificateRequest;
 import org.springframework.vault.support.VaultCertificateResponse;
 
 @Configuration
-@Import(AsyncConfig.class)
 @Slf4j
 public class GrpcConfig extends GRpcServerBuilderConfigurer {
     private final AmbassadorProperties appProperties;

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -189,7 +189,7 @@ public class EnvoyRegistry {
 
     resourceLabelsService.trackResource(tenantId, resourceId);
 
-    return envoyLeaseTracking.grant(envoyId)
+    return envoyLeaseTracking.grant(envoyId, appProperties.getEnvoyLeaseDuration().toSeconds())
         .thenApply(leaseId -> {
           final EnvoyEntry entry = new EnvoyEntry(
               instructionStreamObserver, tenantId, envoyId, resourceId);
@@ -293,28 +293,24 @@ public class EnvoyRegistry {
         .collect(Collectors.toList());
   }
 
-  @Scheduled(fixedDelayString = "${ambassador.envoyRefreshInterval:PT10S}")
+  @Scheduled(fixedDelayString = "${salus.ambassador.envoyRefreshInterval:PT45S}")
   public void refreshEnvoys() {
 
-    envoys.forEachKey(appProperties.getEnvoyRefreshParallelism(), instanceId -> {
-      final EnvoyEntry envoyEntry = envoys.get(instanceId);
-
-      if (envoyEntry != null) {
-        try {
-          synchronized (envoyEntry.instructionStream) {
-            envoyEntry.instructionStream
-                .onNext(TelemetryEdge.EnvoyInstruction.newBuilder()
-                    .setRefresh(
-                        TelemetryEdge.EnvoyInstructionRefresh.newBuilder().build()
-                    )
-                    .build());
-          }
-        } catch (Exception e) {
-          // Most likely exceptions are due to the gRPC connection being closed by
-          // Envoy connection loss or failure to establish attachment. The later
-          // gets thrown as an IllegalStateException.
-          processFailedSend(instanceId, e);
+    envoys.forEach(appProperties.getEnvoyRefreshParallelism(), (instanceId, envoyEntry) -> {
+      try {
+        synchronized (envoyEntry.instructionStream) {
+          envoyEntry.instructionStream
+              .onNext(TelemetryEdge.EnvoyInstruction.newBuilder()
+                  .setRefresh(
+                      TelemetryEdge.EnvoyInstructionRefresh.newBuilder().build()
+                  )
+                  .build());
         }
+      } catch (Exception e) {
+        // Most likely exceptions are due to the gRPC connection being closed by
+        // Envoy connection loss or failure to establish attachment. The later
+        // gets thrown as an IllegalStateException.
+        processFailedSend(instanceId, e);
       }
     });
   }

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistry.java
@@ -293,7 +293,7 @@ public class EnvoyRegistry {
         .collect(Collectors.toList());
   }
 
-  @Scheduled(fixedDelayString = "${salus.ambassador.envoyRefreshInterval:PT45S}")
+  @Scheduled(fixedDelayString = "#{ambassadorProperties.envoyRefreshInterval}")
   public void refreshEnvoys() {
 
     envoys.forEach(appProperties.getEnvoyRefreshParallelism(), (instanceId, envoyEntry) -> {

--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/GrpcContextDetails.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/GrpcContextDetails.java
@@ -82,6 +82,13 @@ public class GrpcContextDetails implements ServerInterceptor {
         return ENVOY_ID.get();
     }
 
+    static Context contextForTesting(String tenantId, String envoyId,
+                                     SocketAddress remoteAddress) {
+        return Context.current().withValues(TENANT_ID, tenantId, ENVOY_ID, envoyId,
+            REMOTE_ADDR, remoteAddress
+        );
+    }
+
     @Override
     public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
             ServerCall<ReqT, RespT> call,

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfigVaultTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/config/GrpcConfigVaultTest.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.ambassador.config;
@@ -31,6 +29,7 @@ import com.rackspace.salus.services.TelemetryAmbassadorGrpc;
 import com.rackspace.salus.services.TelemetryEdge;
 import com.rackspace.salus.telemetry.ambassador.MockAmbassadorService;
 import com.rackspace.salus.telemetry.ambassador.services.GrpcContextDetails;
+import com.rackspace.salus.telemetry.ambassador.services.TestAsyncConfig;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.netty.GrpcSslContexts;
@@ -65,6 +64,7 @@ import org.springframework.vault.support.VaultCertificateResponse;
 @RunWith(SpringRunner.class)
 @SpringBootTest(
     classes = {
+        TestAsyncConfig.class,
         GrpcConfig.class,
         AmbassadorProperties.class,
         GrpcContextDetails.class,

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/EnvoyRegistryTest.java
@@ -78,6 +78,7 @@ import org.springframework.util.concurrent.ListenableFuture;
 @SpringBootTest(classes = {
     EnvoyRegistry.class,
     AmbassadorProperties.class,
+    TestAsyncConfig.class,
     GrpcConfig.class,
     SimpleMeterRegistry.class
 })
@@ -118,7 +119,7 @@ public class EnvoyRegistryTest {
         .build();
 
     final CompletableFuture<Long> assignedLease = CompletableFuture.completedFuture(1234L);
-    when(envoyLeaseTracking.grant(any()))
+    when(envoyLeaseTracking.grant(anyString(), anyLong()))
         .thenReturn(assignedLease);
 
     when(envoyResourceManagement.registerResource(any(), any(), anyLong(), any(), any(), any()))
@@ -179,7 +180,7 @@ public class EnvoyRegistryTest {
         .build();
 
     final CompletableFuture<Long> assignedLease = CompletableFuture.completedFuture(1234L);
-    when(envoyLeaseTracking.grant(any()))
+    when(envoyLeaseTracking.grant(anyString(), anyLong()))
         .thenReturn(assignedLease);
 
     when(envoyResourceManagement.registerResource(any(), any(), anyLong(), any(), any(), any()))
@@ -236,7 +237,7 @@ public class EnvoyRegistryTest {
         .build();
 
     final CompletableFuture<Long> assignedLease = CompletableFuture.completedFuture(1234L);
-    when(envoyLeaseTracking.grant(any()))
+    when(envoyLeaseTracking.grant(anyString(), anyLong()))
         .thenReturn(assignedLease);
 
     when(envoyResourceManagement.registerResource(any(), any(), anyLong(), any(), any(), any()))

--- a/src/test/java/com/rackspace/salus/telemetry/ambassador/services/TestAsyncConfig.java
+++ b/src/test/java/com/rackspace/salus/telemetry/ambassador/services/TestAsyncConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.ambassador.services;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+
+@Configuration
+public class TestAsyncConfig {
+  @Bean
+  public TaskExecutor taskExecutor() {
+    return new SyncTaskExecutor();
+  }
+}


### PR DESCRIPTION
# Part of 

https://jira.rax.io/browse/SALUS-991

# What

When re-evaluating sizing of envoy-ambassador connections I wanted to extend out the default envoy keep alive and lease duration, but found that was awkwardly spread across ambassador properties and etcd-adapter properties.

# How

- shifted the envoy lease duration config to be in `AmbassadorProperties`
- extended out the refresh interval
- added a meter to measure attach duration
- added tenant and resource ID to some of the envoy related logs to make it easier to correlate troubleshooting
- added some more unit tests to EnvoyAmbassadorService since I was thinking about shifting some exception handling in the attach handler

# How to test

Unit tests cover most of the changes, but also tested with envoys in stress-test mode.

# Depends on

https://github.com/racker/salus-telemetry-etcd-adapter/pull/66