### PR TITLE
Added monitor type and scope for test-monitor content translation

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorEventListener.java
+++ b/src/main/java/com/rackspace/salus/telemetry/ambassador/services/TestMonitorEventListener.java
@@ -60,9 +60,11 @@ public class TestMonitorEventListener {
     this.appName = appName;
     this.ourHostName = ourHostName;
 
-    requestsCounter = meterRegistry.counter("testMonitorListener.requests");
-    missingAgentCounter = meterRegistry.counter("testMonitorListener.missingAgent");
-    failedTranslateCounter = meterRegistry.counter("testMonitorListener.failedTranslate");
+    requestsCounter = meterRegistry.counter("testMonitorListenerRequests");
+    missingAgentCounter = meterRegistry.counter("testMonitorListenerErrors",
+        "type", "missingAgent");
+    failedTranslateCounter = meterRegistry.counter("testMonitorListenerErrors",
+        "type", "failedTranslate");
   }
 
   @SuppressWarnings("unused") // in @KafkaListener SpEL
@@ -116,7 +118,7 @@ public class TestMonitorEventListener {
       resultsProducer.send(
           TestMonitorResults.newBuilder()
               .setCorrelationId(event.getCorrelationId())
-              .addErrors("Internal error: "+e.getMessage())
+              .addErrors("Internal error: " + e.getMessage())
               .build()
       );
       return;


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-779

# What

The previous PR https://github.com/racker/salus-telemetry-ambassador/pull/95 didn't take into consideration the monitor type and scope. As a result, the content translation for test-monitors was trying to apply ALL of the translation operations, which failed every time due to conversion of fields that didn't exist.

It also didn't properly handle the exception thrown by the failed REST call to monitor-management. As a result, the test-monitor would time out.

# How

Propagate the monitor type and scope from the requesting event to the content translation call.

Catch exceptions from the translation call and respond to the test-monitor with the exception message.

# How to test

Updated unit tests. End to end testing of a test-monitor is good too.

# Depends on

- https://github.com/racker/salus-telemetry-model/pull/149
- https://github.com/racker/salus-telemetry-monitor-management/pull/198