### PR TITLE
Added starter-data-jpa dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,15 @@
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.rackspace.salus</groupId>
@@ -73,16 +82,6 @@
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-model</artifactId>
             <version>0.1.0-SNAPSHOT</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>spring-boot-starter-jdbc</artifactId>
-                    <groupId>org.springframework.boot</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>spring-jdbc</artifactId>
-                    <groupId>org.springframework</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.rackspace.salus</groupId>
@@ -192,11 +191,6 @@
             <artifactId>podam</artifactId>
             <version>7.2.1.RELEASE</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
# What

With https://github.com/racker/salus-telemetry-ambassador/pull/97 we started to see

```
***************************
APPLICATION FAILED TO START
***************************
Description:
Parameter 3 of constructor in com.rackspace.salus.telemetry.ambassador.services.ResourceLabelsService required a bean named 'entityManagerFactory' that could not be found.
```

# How

The spring-boot-starter-data-jpa dependency was needed to activate auto config.

# How to test

Start up the ambassador process