### PR TITLE
Updated umb-protocol to latest snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>com.rackspace.monplat</groupId>
             <artifactId>umb-protocol</artifactId>
-            <version>0.3.0-SNAPSHOT</version>
+            <version>0.3.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.salus</groupId>


### PR DESCRIPTION
# What

When checking out umb-protocol locally, it helps to have ambassador lined up with the latest snapshot version there.